### PR TITLE
Add support for --fromfile flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Website: [https://peteretelej.github.io/tree/](https://peteretelej.github.io/tre
 - [x] Append file type indicators (`/`, `*`, etc.) (`-F`)
 - [x] Omit summary report (`--noreport`)
 - [x] Print permissions (`-p`)
+- [ ] Read directory listing from a file or stdin (`--fromfile`)
 
 Please feel to open PR requests in case interested in implementing some of the pending features.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -139,6 +139,9 @@ struct Cli {
 
     #[arg(short = 'p', help = "Print the protections for each file (unix only).")]
     print_permissions: bool,
+
+    #[arg(long = "fromfile", help = "Read listing from file/stdin")]
+    fromfile: bool,
 }
 
 fn try_main() -> io::Result<()> {
@@ -180,6 +183,7 @@ fn try_main() -> io::Result<()> {
         classify: cli.classify,
         no_report: cli.no_report,
         print_permissions: cli.print_permissions,
+        from_file: cli.fromfile,
     };
 
     list_directory(&cli.path, &options)

--- a/src/rust_tree/fromfile.rs
+++ b/src/rust_tree/fromfile.rs
@@ -616,5 +616,10 @@ fn normalize_path(path: &str) -> String {
         normalized = format!("{}{}", drive, &normalized[2..]);
     }
 
+    // Strip leading ./ from paths (common in find output)
+    if normalized.starts_with("./") {
+        normalized = normalized[2..].to_string();
+    }
+
     normalized
 }

--- a/src/rust_tree/fromfile.rs
+++ b/src/rust_tree/fromfile.rs
@@ -1,5 +1,5 @@
-use std::io::{self, BufRead, BufReader};
 use std::fs::File;
+use std::io::{self, BufRead, BufReader};
 use std::path::Path;
 
 #[derive(Debug, Clone)]
@@ -33,6 +33,151 @@ pub fn read_file_listing<P: AsRef<Path>>(input_path: P) -> io::Result<Vec<String
     Ok(lines)
 }
 
+pub fn parse_file_listing(lines: Vec<String>) -> Vec<FileEntry> {
+    if let Some(format) = detect_format(&lines) {
+        match format {
+            FileListFormat::Tar => parse_tar_listing(lines),
+            FileListFormat::Simple => parse_simple_paths(lines),
+        }
+    } else {
+        parse_simple_paths(lines)
+    }
+}
+
+#[derive(Debug)]
+enum FileListFormat {
+    Simple,
+    Tar,
+}
+
+fn detect_format(lines: &[String]) -> Option<FileListFormat> {
+    if lines.is_empty() {
+        return None;
+    }
+
+    // Check for tar -tvf format patterns (more specific)
+    let tar_patterns = lines
+        .iter()
+        .take(5)
+        .filter(|line| {
+            // tar -tvf format: "drwxr-xr-x user/group size date path"
+            // Must have at least 6 space-separated parts and start with permission pattern
+            let parts: Vec<&str> = line.split_whitespace().collect();
+            parts.len() >= 6
+                && (line.starts_with("drwx")
+                    || line.starts_with("-rw")
+                    || line.starts_with("lrwx")
+                    || line.starts_with("-rwx"))
+        })
+        .count();
+
+    if tar_patterns > 0 {
+        Some(FileListFormat::Tar)
+    } else {
+        Some(FileListFormat::Simple)
+    }
+}
+
+fn parse_tar_listing(lines: Vec<String>) -> Vec<FileEntry> {
+    let mut entries = std::collections::HashMap::new();
+
+    for line in lines {
+        if let Some(entry) = parse_tar_line(&line) {
+            if entry.path.is_empty() {
+                continue;
+            }
+
+            // Add the entry itself
+            entries.insert(entry.path.clone(), entry.clone());
+
+            // Add parent directories
+            let path_parts: Vec<&str> = entry.path.split('/').collect();
+            for i in 1..path_parts.len() {
+                let parent_path = path_parts[..i].join("/");
+                if !parent_path.is_empty() {
+                    entries
+                        .entry(parent_path.clone())
+                        .or_insert_with(|| FileEntry {
+                            path: parent_path,
+                            is_dir: true,
+                            size: None,
+                        });
+                }
+            }
+        }
+    }
+
+    entries.into_values().collect()
+}
+
+fn parse_tar_line(line: &str) -> Option<FileEntry> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    // Handle both tar -tf and tar -tvf formats
+    if line.starts_with('d') || line.starts_with('-') || line.starts_with('l') {
+        // tar -tvf format: "drwxr-xr-x user/group 0 date path"
+        parse_tar_verbose_line(line)
+    } else {
+        // tar -tf format: just the path
+        parse_tar_simple_line(line)
+    }
+}
+
+fn parse_tar_verbose_line(line: &str) -> Option<FileEntry> {
+    let parts: Vec<&str> = line.split_whitespace().collect();
+    if parts.len() < 6 {
+        return None;
+    }
+
+    let permissions = parts[0];
+    let is_dir = permissions.starts_with('d');
+
+    // Size is typically at index 2
+    let size = if parts.len() > 2 {
+        parts[2].parse::<u64>().ok()
+    } else {
+        None
+    };
+
+    // Path is the last part (may contain spaces, so rejoin)
+    let path_start = line.rfind(' ')?;
+    let path = &line[path_start + 1..];
+
+    let clean_path = if is_dir && path.ends_with('/') {
+        path.trim_end_matches('/')
+    } else {
+        path
+    };
+
+    Some(FileEntry {
+        path: clean_path.to_string(),
+        is_dir,
+        size,
+    })
+}
+
+fn parse_tar_simple_line(line: &str) -> Option<FileEntry> {
+    let is_dir = line.ends_with('/');
+    let clean_path = if is_dir {
+        line.trim_end_matches('/')
+    } else {
+        line
+    };
+
+    if clean_path.is_empty() {
+        return None;
+    }
+
+    Some(FileEntry {
+        path: clean_path.to_string(),
+        is_dir,
+        size: None,
+    })
+}
+
 pub fn parse_simple_paths(lines: Vec<String>) -> Vec<FileEntry> {
     let mut entries = std::collections::HashMap::new();
 
@@ -49,22 +194,27 @@ pub fn parse_simple_paths(lines: Vec<String>) -> Vec<FileEntry> {
         }
 
         // Add the entry itself
-        entries.insert(clean_path.to_string(), FileEntry {
-            path: clean_path.to_string(),
-            is_dir,
-            size: None,
-        });
+        entries.insert(
+            clean_path.to_string(),
+            FileEntry {
+                path: clean_path.to_string(),
+                is_dir,
+                size: None,
+            },
+        );
 
         // Add parent directories
         let path_parts: Vec<&str> = clean_path.split('/').collect();
         for i in 1..path_parts.len() {
             let parent_path = path_parts[..i].join("/");
             if !parent_path.is_empty() {
-                entries.entry(parent_path.clone()).or_insert_with(|| FileEntry {
-                    path: parent_path,
-                    is_dir: true,
-                    size: None,
-                });
+                entries
+                    .entry(parent_path.clone())
+                    .or_insert_with(|| FileEntry {
+                        path: parent_path,
+                        is_dir: true,
+                        size: None,
+                    });
             }
         }
     }

--- a/src/rust_tree/fromfile.rs
+++ b/src/rust_tree/fromfile.rs
@@ -1,0 +1,80 @@
+use std::io::{self, BufRead, BufReader};
+use std::fs::File;
+use std::path::Path;
+
+#[derive(Debug, Clone)]
+pub struct FileEntry {
+    pub path: String,
+    pub is_dir: bool,
+    pub size: Option<u64>,
+}
+
+pub struct VirtualTree {
+    pub entries: Vec<FileEntry>,
+    pub root_name: String,
+}
+
+pub fn read_file_listing<P: AsRef<Path>>(input_path: P) -> io::Result<Vec<String>> {
+    let path = input_path.as_ref();
+    let reader: Box<dyn BufRead> = if path.to_str() == Some(".") {
+        Box::new(BufReader::new(io::stdin()))
+    } else {
+        Box::new(BufReader::new(File::open(path)?))
+    };
+
+    let mut lines = Vec::new();
+    for line in reader.lines() {
+        let line = line?;
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            lines.push(trimmed.to_string());
+        }
+    }
+    Ok(lines)
+}
+
+pub fn parse_simple_paths(lines: Vec<String>) -> Vec<FileEntry> {
+    let mut entries = std::collections::HashMap::new();
+
+    for line in lines {
+        let is_dir = line.ends_with('/');
+        let clean_path = if is_dir {
+            line.trim_end_matches('/')
+        } else {
+            &line
+        };
+
+        if clean_path.is_empty() {
+            continue;
+        }
+
+        // Add the entry itself
+        entries.insert(clean_path.to_string(), FileEntry {
+            path: clean_path.to_string(),
+            is_dir,
+            size: None,
+        });
+
+        // Add parent directories
+        let path_parts: Vec<&str> = clean_path.split('/').collect();
+        for i in 1..path_parts.len() {
+            let parent_path = path_parts[..i].join("/");
+            if !parent_path.is_empty() {
+                entries.entry(parent_path.clone()).or_insert_with(|| FileEntry {
+                    path: parent_path,
+                    is_dir: true,
+                    size: None,
+                });
+            }
+        }
+    }
+
+    entries.into_values().collect()
+}
+
+pub fn build_virtual_tree(entries: Vec<FileEntry>) -> VirtualTree {
+    VirtualTree {
+        entries,
+        root_name: ".".to_string(),
+    }
+}

--- a/src/rust_tree/mod.rs
+++ b/src/rust_tree/mod.rs
@@ -1,4 +1,5 @@
 pub mod display;
+pub mod fromfile;
 pub mod options;
 pub mod traversal;
 pub mod utils;

--- a/src/rust_tree/options.rs
+++ b/src/rust_tree/options.rs
@@ -22,4 +22,5 @@ pub struct TreeOptions {
     pub classify: bool,
     pub no_report: bool,
     pub print_permissions: bool,
+    pub from_file: bool,
 }

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -439,7 +439,7 @@ pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io
 fn list_from_input(input_path: &Path, options: &TreeOptions) -> std::io::Result<()> {
     let lines = read_file_listing(input_path)?;
     let entries = parse_file_listing(lines);
-    let virtual_tree = build_virtual_tree(entries);
+    let virtual_tree = build_virtual_tree(entries, options);
     display_virtual_tree(virtual_tree, options)
 }
 


### PR DESCRIPTION
The [--fromfile](https://man.archlinux.org/man/tree.1.en#fromfile) flag is used to read directory listings from files instead of directly from scanning the directory. 

As requested and discussed [here](https://github.com/peteretelej/tree/issues/19), this change adds support for `--fromfile`

Example usage(s)
```bash
# output from find
find . -name "*.rs" | ./tree --fromfile .

# output from popular archive formats
tar -tf archive.tar | tree --fromfile .
unzip -l archive.zip | tree --fromfile .
7z l archive.7z| tree --fromfile .
```

Fixes #19 