### PR TITLE
qa: Add QA test tooling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@ Cargo.lock text eol=lf
 *.jpg binary
 
 store-assets/** linguist-vendored
+tests/qa/** linguist-vendored

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Consider copying the `pre-push` script to your git hooks directory:
 cp scripts/pre-push .git/hooks/pre-push
 ```
 
+#### QA Testing
+
+The folder [`tests/qa`](tests/qa) contains scripts for manual QA testing of the `tree` CLI tool. These scripts are designed to validate the features as advertised in this README. This is intended to exclusively use the generated binaries and not code or existing tests. Please manually run QA tests before any releases (TODO: add to release pipeline).
+
+```bash
+# Run all platforms (Ubuntu, Alpine Linux, and Windows  - if on Windows)
+cd tests/qa && ./qa-test.sh
+
+# Test specific platform
+./qa-test.sh --linux
+```
+
+Requires Docker. Tests run in isolated containers with detailed failure reports including exact commands, exit codes, and output differences. See [`tests/qa/README.md`](tests/qa/README.md) for full documentation.
+
 #### VS Code Settings
 
 For VS Code users, add this to your settings.json:

--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -1,5 +1,4 @@
-// CLI module - handles command line argument parsing and execution
-// Moved from main.rs to make it testable
+// CLI module - handles cli flag parsing
 
 use clap::Parser;
 use glob::Pattern;

--- a/src/rust_tree/display.rs
+++ b/src/rust_tree/display.rs
@@ -2,6 +2,7 @@ use ansi_term::Colour::{Blue, Cyan, Green, Red, Yellow};
 use is_executable::IsExecutable;
 use std::fs;
 
+// Colorize the tree output based on the file type and extension.
 pub fn colorize(entry: &fs::DirEntry, text: &str) -> String {
     let file_type = match entry.file_type() {
         Ok(ft) => ft,

--- a/tests/qa/.dockerignore
+++ b/tests/qa/.dockerignore
@@ -1,0 +1,23 @@
+# Ignore build artifacts and logs
+target/
+tests/qa/logs/
+*.log
+
+# Ignore git and IDE files
+.git/
+.gitignore
+.vscode/
+.idea/
+
+# Ignore documentation that's not needed for testing
+docs/
+README.md
+LICENSE
+
+# Ignore store assets
+store-assets/
+wix/
+
+# Ignore coverage and test artifacts
+coverage/
+*.profraw

--- a/tests/qa/.gitignore
+++ b/tests/qa/.gitignore
@@ -1,0 +1,2 @@
+# All QA temporary files in one directory
+temp/

--- a/tests/qa/Dockerfile.alpine
+++ b/tests/qa/Dockerfile.alpine
@@ -1,0 +1,33 @@
+# Alpine-based testing environment for tree CLI (musl compatibility)
+FROM alpine:3.19
+
+# Set environment variables
+ENV RUST_VERSION=stable
+
+# Install system dependencies
+RUN apk add --no-cache \
+    curl \
+    build-base \
+    git \
+    ca-certificates \
+    musl-dev \
+    bash
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Set working directory
+WORKDIR /app
+
+# Copy the entire project
+COPY . .
+
+# Make test script executable
+RUN chmod +x /app/tests/qa/qa-docker-test.sh
+
+# Default command runs the QA tests
+CMD ["./tests/qa/qa-docker-test.sh"]

--- a/tests/qa/Dockerfile.linux
+++ b/tests/qa/Dockerfile.linux
@@ -1,0 +1,33 @@
+# Ubuntu-based testing environment for tree CLI
+FROM ubuntu:22.04
+
+# Set environment variables
+ENV RUST_VERSION=stable
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    curl \
+    build-essential \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Verify Rust installation
+RUN rustc --version && cargo --version
+
+# Set working directory
+WORKDIR /app
+
+# Copy the entire project
+COPY . .
+
+# Make test script executable
+RUN chmod +x /app/tests/qa/qa-docker-test.sh
+
+# Default command runs the QA tests
+CMD ["./tests/qa/qa-docker-test.sh"]

--- a/tests/qa/Dockerfile.windows
+++ b/tests/qa/Dockerfile.windows
@@ -1,0 +1,40 @@
+# Windows-based testing environment for tree CLI
+# Requires Windows Docker host
+FROM mcr.microsoft.com/windows/servercore:ltsc2022
+
+# Set PowerShell as default shell
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# Install Chocolatey
+RUN Set-ExecutionPolicy Bypass -Scope Process -Force; \
+    [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; \
+    iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+
+# Install Git and Visual Studio Build Tools
+RUN choco install -y git visualstudio2022buildtools --package-parameters "--add Microsoft.VisualStudio.Workload.VCTools --includeRecommended"
+
+# Install Rust (stable and 1.75 for Windows 7 compatibility)
+RUN Invoke-WebRequest -Uri 'https://win.rustup.rs/x86_64' -OutFile 'rustup-init.exe'; \
+    ./rustup-init.exe -y --default-toolchain stable; \
+    Remove-Item rustup-init.exe
+
+# Add Rust to PATH
+RUN $env:PATH = $env:USERPROFILE + '\.cargo\bin;' + $env:PATH; \
+    [Environment]::SetEnvironmentVariable('PATH', $env:PATH, [EnvironmentVariableTarget]::Machine)
+
+# Install Rust 1.75 for Windows 7 compatibility
+RUN $env:PATH = $env:USERPROFILE + '\.cargo\bin;' + $env:PATH; \
+    rustup install 1.75.0
+
+# Verify Rust installation
+RUN $env:PATH = $env:USERPROFILE + '\.cargo\bin;' + $env:PATH; \
+    rustc --version; cargo --version
+
+# Set working directory
+WORKDIR C:/app
+
+# Copy the entire project
+COPY . .
+
+# Default command runs the QA tests
+CMD ["powershell", "-File", "tests/qa/qa-docker-test.ps1"]

--- a/tests/qa/README.md
+++ b/tests/qa/README.md
@@ -1,0 +1,143 @@
+# QA Testing for Tree CLI
+
+This directory contains comprehensive Docker-based QA test scripts for validating the tree CLI functionality across different platforms in isolated containers.
+
+## Purpose
+
+Manual QA testing scripts that validate all features advertised in the README using built binaries in clean Docker environments. These tests are designed to catch real-world usage issues and cross-platform compatibility problems without polluting the host filesystem.
+
+## Docker-Based Testing
+
+All testing runs inside Docker containers to ensure:
+- Clean, reproducible environments
+- No host filesystem pollution  
+- Accurate cross-platform testing
+- Isolated build and test environments
+
+## Test Scripts
+
+### `qa-test.sh` (Host orchestrator)
+Bash script that orchestrates Docker containers for testing on different platforms.
+
+### `qa-docker-test.sh` (Container test script)
+Internal script that runs inside Docker containers to perform the actual testing.
+
+## Features Tested
+
+### Core Functionality
+- Basic directory tree display
+- Depth control (`-L`/`--level`)
+- Full path display (`-f`/`--full-path`)
+- No indentation (`-i`/`--no-indent`)
+- Hidden files (`-a`/`--all`)
+
+### File Filtering & Pattern Matching
+- Include patterns (`-P`/`--pattern`)
+- Exclude patterns (`-I`/`--exclude`)
+- Directories only (`-d`/`--directories`)
+- File limit per directory (`--filelimit`)
+
+### Display Options
+- File sizes (`-s`/`--size`)
+- Human readable sizes (`-H`/`--human-readable`)
+- Colorization (`-C`/`--color`, `-n`/`--no-color`)
+- ASCII characters (`-A`/`--ascii`)
+- File type indicators (`-F`)
+- Permissions (`-p`)
+- Modification dates (`-D`)
+
+### Sorting & Output
+- Sort by modification time (`-t`)
+- Reverse sorting (`-r`)
+- Directories first (`--dirsfirst`)
+- Output to file (`-o`)
+- No summary report (`--noreport`)
+
+### Advanced Features
+- Read from file/stdin (`--fromfile`)
+- Archive format support (TAR, ZIP, 7z, RAR)
+
+## Test Environment
+
+Each script creates a comprehensive test directory structure with:
+- Regular files and directories
+- Hidden files (starting with `.`)
+- Files with different extensions
+- Nested directory structures
+- Files with various sizes
+- Symbolic links (Unix systems)
+- Files with different modification times
+
+## Docker Images
+
+### `Dockerfile.linux` (Ubuntu-based)
+Tests on Ubuntu with latest Rust toolchain for modern Linux compatibility.
+
+### `Dockerfile.alpine` (Alpine-based) 
+Tests on Alpine Linux for minimal environment and musl compatibility.
+
+### `Dockerfile.windows` (Windows-based)
+Tests on Windows Server Core with both modern Rust and Windows 7 compatibility (Rust 1.75).
+
+## Usage
+
+### Run All Platform Tests (Default)
+```bash
+cd tests/qa
+./qa-test.sh
+```
+
+### Run Specific Platform
+```bash
+# Test Ubuntu Linux only
+./qa-test.sh --linux
+
+# Test Alpine Linux only
+./qa-test.sh --alpine
+
+# Test multiple specific platforms
+./qa-test.sh --linux --alpine
+
+# Test Windows (requires Windows Docker)
+./qa-test.sh --windows
+
+# Explicitly run all platforms
+./qa-test.sh --all
+```
+
+### Run with Docker Compose
+```bash
+docker-compose up --build
+```
+
+## Test Reports
+
+Scripts generate detailed logs in the `temp/` directory showing:
+- Test results (PASS/FAIL) for each feature
+- Error messages and outputs
+- Performance timing
+- Binary information (version, size, platform)
+- Summary report with pass/fail counts
+
+All temporary files (logs, test artifacts, Docker build cache) are consolidated in `tests/qa/temp/` and ignored by Git.
+
+## Requirements
+
+### Host System
+- Docker Engine
+- Docker Compose (optional, for multi-platform testing)
+- Bash (for orchestration scripts)
+
+### Container Environments
+- All Rust toolchains and dependencies are installed in containers
+- No host Rust installation required
+- Windows containers require Windows Docker host for Windows testing
+
+## Notes
+
+- Tests are designed to be run manually, not in CI/CD
+- Each platform test runs in complete isolation
+- All build artifacts and test files remain in containers
+- Host filesystem stays clean - no test pollution
+- Tests use release build binaries for realistic performance testing
+- Containers are automatically cleaned up after testing

--- a/tests/qa/docker-compose.yml
+++ b/tests/qa/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.8'
+
+services:
+  # Ubuntu Linux testing
+  tree-qa-linux:
+    build:
+      context: ../..
+      dockerfile: tests/qa/Dockerfile.linux
+    container_name: tree-qa-linux
+    environment:
+      - RUST_LOG=info
+    
+  # Alpine Linux testing (musl compatibility)
+  tree-qa-alpine:
+    build:
+      context: ../..
+      dockerfile: tests/qa/Dockerfile.alpine
+    container_name: tree-qa-alpine
+    environment:
+      - RUST_LOG=info
+
+  # Windows testing (requires Windows Docker host)
+  # Uncomment when running on Windows Docker host
+  # tree-qa-windows:
+  #   build:
+  #     context: ../..
+  #     dockerfile: tests/qa/Dockerfile.windows
+  #   container_name: tree-qa-windows
+  #   environment:
+  #     - RUST_LOG=info

--- a/tests/qa/qa-docker-test.ps1
+++ b/tests/qa/qa-docker-test.ps1
@@ -1,0 +1,368 @@
+# Docker Container Test Script for Tree CLI (Windows PowerShell)
+# This script runs inside Windows Docker containers to perform the actual QA testing
+
+param(
+    [switch]$Win7Test = $false,
+    [switch]$Verbose = $false
+)
+
+# Test counters
+$script:TotalTests = 0
+$script:PassedTests = 0
+$script:FailedTests = 0
+
+function Write-Log {
+    param($Message)
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $logEntry = "$timestamp - $Message"
+    Write-Output $logEntry
+}
+
+function Write-TestLog {
+    param($Message)
+    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+    $logEntry = "$timestamp - TEST: $Message"
+    if ($Verbose) { Write-Output $logEntry }
+}
+
+function Write-TestResult {
+    param(
+        [string]$Result,
+        [string]$TestName,
+        [string]$Details = ""
+    )
+    
+    $script:TotalTests++
+    
+    if ($Result -eq "PASS") {
+        $script:PassedTests++
+        Write-Host "✓ PASS: $TestName" -ForegroundColor Green
+    } else {
+        $script:FailedTests++
+        Write-Host "✗ FAIL: $TestName" -ForegroundColor Red
+        if ($Details) {
+            Write-Host "  Details: $Details" -ForegroundColor Yellow
+        }
+    }
+    
+    # Results are output to console for Docker logging
+}
+
+function Invoke-Test {
+    param(
+        [string]$TestName,
+        [string]$Command,
+        [string]$ExpectedPattern = "",
+        [bool]$ShouldFail = $false
+    )
+    
+    Write-TestLog $TestName
+    Write-Host "  Command: $Command"
+    
+    try {
+        if ($ShouldFail) {
+            $output = Invoke-Expression $Command 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                Write-TestResult "FAIL" $TestName "Command should have failed but succeeded"
+                Write-Host "  Exit code: $LASTEXITCODE"
+                Write-Host "  Output: $($output | Select-Object -First 3)"
+            } else {
+                Write-TestResult "PASS" $TestName
+                Write-Host "  Exit code: $LASTEXITCODE"
+            }
+        } else {
+            $output = Invoke-Expression $Command 2>&1
+            if ($LASTEXITCODE -eq 0) {
+                if ($ExpectedPattern -and $output -notmatch $ExpectedPattern) {
+                    Write-TestResult "FAIL" $TestName "Output doesn't match expected pattern: $ExpectedPattern"
+                    Write-Host "  Exit code: $LASTEXITCODE"
+                    Write-Host "  Expected pattern: '$ExpectedPattern'"
+                    Write-Host "  Actual output:"
+                    ($output | Select-Object -First 5) | ForEach-Object { Write-Host "    $_" }
+                } else {
+                    Write-TestResult "PASS" $TestName
+                }
+            } else {
+                Write-TestResult "FAIL" $TestName "Command failed unexpectedly"
+                Write-Host "  Exit code: $LASTEXITCODE"
+                Write-Host "  Output: $($output | Select-Object -First 3)"
+            }
+        }
+    }
+    catch {
+        Write-TestResult "FAIL" $TestName "Exception: $($_.Exception.Message)"
+        Write-Host "  Exception details: $($_.Exception.Message)"
+    }
+}
+
+function Setup-TestEnvironment {
+    Write-Log "Setting up test environment..."
+    
+    # Create test directory structure in container temp
+    $script:TestDir = "C:\temp\qa_test"
+    New-Item -ItemType Directory -Path $TestDir -Force | Out-Null
+    Set-Location $TestDir
+    
+    # Create various test files and directories
+    New-Item -ItemType Directory -Path "dir1\subdir1", "dir1\subdir2", "dir2" -Force | Out-Null
+    New-Item -ItemType File -Path "file1.txt", "file2.log", "file3.py" | Out-Null
+    New-Item -ItemType File -Path "dir1\file_in_dir1.txt", "dir1\subdir1\deep_file.txt" | Out-Null
+    
+    # Create files with different sizes
+    "small file" | Out-File -FilePath "small.txt" -Encoding ASCII
+    $largeContent = "0" * 10240  # 10KB file
+    $largeContent | Out-File -FilePath "large.bin" -Encoding ASCII
+    
+    # Set different modification times
+    $oldDate = Get-Date "2023-01-01"
+    $oldFile = New-Item -ItemType File -Path "old_file.txt"
+    $oldFile.LastWriteTime = $oldDate
+    
+    New-Item -ItemType File -Path "new_file.txt" | Out-Null
+    
+    # Create files for pattern testing
+    New-Item -ItemType File -Path "script.ps1", "config.ini", "README.md" | Out-Null
+    
+    Write-Log "Test environment created in: $(Get-Location)"
+}
+
+function Cleanup-TestEnvironment {
+    Write-Log "Cleaning up test environment..."
+    Set-Location C:\app
+    Remove-Item -Path $TestDir -Recurse -Force -ErrorAction SilentlyContinue
+    Write-Log "Test environment cleaned up"
+}
+
+function Build-Binary {
+    param([bool]$UseWin7Lock = $false)
+    
+    if ($UseWin7Lock) {
+        Write-Log "Building tree binary with Windows 7 compatibility..."
+        # Check if Rust 1.75.0 is available
+        $rustVersions = rustup toolchain list
+        if ($rustVersions -notmatch "1\.75\.0") {
+            Write-Log "Installing Rust 1.75.0 for Windows 7 compatibility..."
+            rustup install 1.75.0
+        }
+        
+        # Backup current Cargo.lock and use Win7 lock
+        if (Test-Path "Cargo.lock") {
+            Copy-Item "Cargo.lock" "Cargo.lock.backup"
+        }
+        Copy-Item "Cargo-win7.lock" "Cargo.lock"
+        
+        $buildResult = rustup run 1.75.0 cargo build --release 2>&1
+        
+        # Restore original Cargo.lock
+        if (Test-Path "Cargo.lock.backup") {
+            Move-Item "Cargo.lock.backup" "Cargo.lock" -Force
+        }
+    } else {
+        Write-Log "Building tree binary..."
+        $buildResult = cargo build --release 2>&1
+    }
+    
+    if ($LASTEXITCODE -eq 0) {
+        $script:TreeBinary = "C:\app\target\release\tree.exe"
+        Write-Log "Binary built successfully: $TreeBinary"
+        
+        # Get binary info
+        if (Test-Path $TreeBinary) {
+            $binaryInfo = Get-Item $TreeBinary | Select-Object Name, Length, LastWriteTime
+            Write-Log "Binary info: $($binaryInfo | Out-String)"
+        }
+        
+        return $true
+    } else {
+        Write-Log "Failed to build binary"
+        return $false
+    }
+}
+
+function Test-BasicFunctionality {
+    Write-Log "Testing basic functionality..."
+    
+    Invoke-Test "Basic tree display" "& '$TreeBinary' ." "dir1"
+    Invoke-Test "Help flag" "& '$TreeBinary' --help" "USAGE"
+    Invoke-Test "Version flag" "& '$TreeBinary' --version" ""
+    
+    # Test with non-existent directory
+    Invoke-Test "Non-existent directory" "& '$TreeBinary' 'C:\non\existent\path'" "" $true
+}
+
+function Test-DepthAndStructure {
+    Write-Log "Testing depth and structure options..."
+    
+    Invoke-Test "Depth level 1" "& '$TreeBinary' -L 1 ." "dir1"
+    Invoke-Test "Depth level 2" "& '$TreeBinary' --level=2 ." "subdir1"
+    Invoke-Test "No indentation" "& '$TreeBinary' -i ." ""
+    Invoke-Test "Full path" "& '$TreeBinary' -f ." ".\"
+    Invoke-Test "ASCII characters" "& '$TreeBinary' -A ." ""
+}
+
+function Test-FileFiltering {
+    Write-Log "Testing file filtering options..."
+    
+    Invoke-Test "Directories only" "& '$TreeBinary' -d ." "dir1"
+    Invoke-Test "Pattern include .txt files" "& '$TreeBinary' -P '*.txt' ." "file1.txt"
+    Invoke-Test "Pattern exclude .log files" "& '$TreeBinary' -I '*.log' ." ""
+    Invoke-Test "File limit" "& '$TreeBinary' --filelimit=5 ." ""
+}
+
+function Test-DisplayOptions {
+    Write-Log "Testing display options..."
+    
+    Invoke-Test "Show file sizes" "& '$TreeBinary' -s ." ""
+    Invoke-Test "Human readable sizes" "& '$TreeBinary' -H ." ""
+    Invoke-Test "Color output" "& '$TreeBinary' -C ." ""
+    Invoke-Test "No color output" "& '$TreeBinary' -n ." ""
+    Invoke-Test "File type indicators" "& '$TreeBinary' -F ." ""
+    Invoke-Test "Show permissions" "& '$TreeBinary' -p ." ""
+    Invoke-Test "Show modification dates" "& '$TreeBinary' -D ." ""
+}
+
+function Test-SortingOptions {
+    Write-Log "Testing sorting options..."
+    
+    Invoke-Test "Sort by time" "& '$TreeBinary' -t ." ""
+    Invoke-Test "Reverse sort" "& '$TreeBinary' -r ." ""
+    Invoke-Test "Directories first" "& '$TreeBinary' --dirsfirst ." ""
+    Invoke-Test "No report" "& '$TreeBinary' --noreport ." ""
+}
+
+function Test-OutputOptions {
+    Write-Log "Testing output options..."
+    
+    $outputFile = "test_output.txt"
+    Invoke-Test "Output to file" "& '$TreeBinary' -o $outputFile ." ""
+    
+    if (Test-Path $outputFile) {
+        $fileSize = (Get-Item $outputFile).Length
+        if ($fileSize -gt 0) {
+            Write-TestResult "PASS" "Output file created and has content"
+        } else {
+            Write-TestResult "FAIL" "Output file created but is empty"
+        }
+        Remove-Item $outputFile -Force
+    } else {
+        Write-TestResult "FAIL" "Output file was not created"
+    }
+}
+
+function Test-FromfileFunctionality {
+    Write-Log "Testing fromfile functionality..."
+    
+    # Create a simple file listing
+    @"
+dir1/
+dir1/file1.txt
+dir2/
+file1.txt
+file2.txt
+"@ | Out-File -FilePath "file_list.txt" -Encoding ASCII
+    
+    Invoke-Test "Read from file" "& '$TreeBinary' --fromfile file_list.txt" "dir1"
+    
+    # Test reading from stdin (PowerShell equivalent)
+    $stdinContent = "test/`ntest/file.txt"
+    Invoke-Test "Read from stdin" "echo '$stdinContent' | & '$TreeBinary' --fromfile" "test"
+    
+    Remove-Item "file_list.txt" -Force
+}
+
+function Test-CombinedOptions {
+    Write-Log "Testing combined options..."
+    
+    Invoke-Test "Multiple flags combination" "& '$TreeBinary' -f -s -L 2 ." ""
+    Invoke-Test "Long flags combination" "& '$TreeBinary' --full-path --size --level=2 ." ""
+    Invoke-Test "Pattern with exclusion" "& '$TreeBinary' -P '*.txt' -I 'large*' ." ""
+}
+
+function Test-ErrorConditions {
+    Write-Log "Testing error conditions..."
+    
+    Invoke-Test "Invalid flag" "& '$TreeBinary' --invalid-flag ." "" $true
+    Invoke-Test "Invalid level value" "& '$TreeBinary' -L abc ." "" $true
+    Invoke-Test "Invalid file limit" "& '$TreeBinary' --filelimit=-1 ." "" $true
+}
+
+function Show-Summary {
+    Write-Log ""
+    Write-Log "========================================="
+    Write-Log "QA Test Summary"
+    Write-Log "========================================="
+    Write-Log "Total tests: $TotalTests"
+    Write-Log "Passed: $PassedTests"
+    Write-Log "Failed: $FailedTests"
+    if ($TotalTests -gt 0) {
+        $successRate = [math]::Round(($PassedTests * 100 / $TotalTests), 2)
+        Write-Log "Success rate: $successRate%"
+    }
+    Write-Log "Log file: $LogFile"
+    Write-Log "========================================="
+    
+    Write-Host ""
+    Write-Host "=========================================" -ForegroundColor Blue
+    Write-Host "QA Test Summary" -ForegroundColor Blue
+    Write-Host "=========================================" -ForegroundColor Blue
+    Write-Host "Total tests: " -NoNewline; Write-Host $TotalTests -ForegroundColor Yellow
+    Write-Host "Passed: " -NoNewline; Write-Host $PassedTests -ForegroundColor Green
+    Write-Host "Failed: " -NoNewline; Write-Host $FailedTests -ForegroundColor Red
+    if ($TotalTests -gt 0) {
+        $successRate = [math]::Round(($PassedTests * 100 / $TotalTests), 2)
+        Write-Host "Success rate: " -NoNewline; Write-Host "$successRate%" -ForegroundColor Yellow
+    }
+    Write-Host "Log file: " -NoNewline; Write-Host $LogFile -ForegroundColor Blue
+    Write-Host "=========================================" -ForegroundColor Blue
+    
+    if ($FailedTests -gt 0) {
+        exit 1
+    }
+}
+
+function Main {
+    Write-Log "Starting QA tests for tree CLI (Windows)"
+    Write-Log "Platform: $([System.Environment]::OSVersion.VersionString)"
+    Write-Log "PowerShell Version: $($PSVersionTable.PSVersion)"
+    Write-Log "Date: $(Get-Date)"
+    if ($Win7Test) {
+        Write-Log "Windows 7 compatibility testing enabled"
+    }
+    Write-Log ""
+    
+    # Build the binary
+    if (-not (Build-Binary -UseWin7Lock $Win7Test)) {
+        Write-Log "Failed to build binary, exiting"
+        exit 1
+    }
+    
+    # Setup test environment
+    Setup-TestEnvironment
+    
+    # Run all test suites
+    Test-BasicFunctionality
+    Test-DepthAndStructure
+    Test-FileFiltering
+    Test-DisplayOptions
+    Test-SortingOptions
+    Test-OutputOptions
+    Test-FromfileFunctionality
+    Test-CombinedOptions
+    Test-ErrorConditions
+    
+    # Cleanup
+    Cleanup-TestEnvironment
+    
+    # Print summary
+    Show-Summary
+}
+
+# Run main function
+try {
+    Main
+}
+catch {
+    Write-Log "Unhandled exception: $($_.Exception.Message)"
+    Write-Host "Unhandled exception: $($_.Exception.Message)" -ForegroundColor Red
+    exit 1
+}

--- a/tests/qa/qa-docker-test.sh
+++ b/tests/qa/qa-docker-test.sh
@@ -1,0 +1,295 @@
+#!/bin/bash
+
+# Docker Container Test Script for Tree CLI
+# This script runs inside Docker containers to perform the actual QA testing
+
+set -e
+
+# Test counters
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $1"
+}
+
+log_test() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - TEST: $1"
+}
+
+log_result() {
+    local result="$1"
+    local test_name="$2"
+    local details="$3"
+    
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    
+    if [ "$result" = "PASS" ]; then
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+        echo "✓ PASS: $test_name"
+    else
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        echo "✗ FAIL: $test_name"
+        if [ -n "$details" ]; then
+            echo "  Details: $details"
+        fi
+    fi
+}
+
+run_test() {
+    local test_name="$1"
+    local command="$2"
+    local expected_pattern="$3"
+    local should_fail="$4"
+    
+    log_test "$test_name"
+    echo "  Command: $command"
+    
+    if [ "$should_fail" = "true" ]; then
+        if output=$($command 2>&1); then
+            exit_code=$?
+            log_result "FAIL" "$test_name" "Command should have failed but succeeded"
+            echo "  Exit code: $exit_code"
+            echo "  Output: $output" | head -3
+        else
+            exit_code=$?
+            log_result "PASS" "$test_name"
+            echo "  Exit code: $exit_code"
+        fi
+    else
+        if output=$($command 2>&1); then
+            exit_code=$?
+            if [ -n "$expected_pattern" ]; then
+                if echo "$output" | grep -q "$expected_pattern"; then
+                    log_result "PASS" "$test_name"
+                else
+                    log_result "FAIL" "$test_name" "Output doesn't match expected pattern: $expected_pattern"
+                    echo "  Exit code: $exit_code"
+                    echo "  Expected pattern: '$expected_pattern'"
+                    echo "  Actual output:"
+                    echo "$output" | head -5 | sed 's/^/    /'
+                fi
+            else
+                log_result "PASS" "$test_name"
+            fi
+        else
+            exit_code=$?
+            log_result "FAIL" "$test_name" "Command failed unexpectedly"
+            echo "  Exit code: $exit_code"
+            echo "  Output: $output" | head -3
+        fi
+    fi
+}
+
+setup_test_environment() {
+    log "Setting up test environment..."
+    
+    # Create test directory structure in container temp
+    TEST_DIR="/tmp/qa_test"
+    mkdir -p "$TEST_DIR"
+    cd "$TEST_DIR"
+    
+    # Create various test files and directories
+    mkdir -p dir1/subdir1 dir1/subdir2 dir2 .hidden_dir
+    touch file1.txt file2.log file3.py .hidden_file
+    touch dir1/file_in_dir1.txt dir1/subdir1/deep_file.txt
+    touch .hidden_dir/hidden_file.txt
+    
+    # Create files with different sizes
+    echo "small file" > small.txt
+    dd if=/dev/zero of=large.bin bs=1024 count=10 2>/dev/null
+    
+    # Create symlinks (if supported)
+    if ln -s file1.txt symlink.txt 2>/dev/null; then
+        log "Created symbolic links for testing"
+    fi
+    
+    # Set different modification times
+    touch -t 202301010000 old_file.txt
+    touch new_file.txt
+    
+    # Create files for pattern testing
+    touch script.sh config.ini README.md
+    
+    log "Test environment created in: $(pwd)"
+}
+
+build_binary() {
+    log "Building tree binary..."
+    cd /app
+    
+    # Clean and build release binary
+    cargo clean >/dev/null 2>&1
+    if cargo build --release >/dev/null 2>&1; then
+        TREE_BINARY="/app/target/release/tree"
+        log "Binary built successfully: $TREE_BINARY"
+        
+        # Get binary info
+        ls -la "$TREE_BINARY"
+        
+        return 0
+    else
+        log "Failed to build binary"
+        return 1
+    fi
+}
+
+test_basic_functionality() {
+    log "Testing basic functionality..."
+    
+    run_test "Basic tree display" "$TREE_BINARY ." "dir1"
+    run_test "Help flag" "$TREE_BINARY --help" "tree"
+    run_test "Version flag" "$TREE_BINARY --version" ""
+    
+    # Test with non-existent directory - should fail like standard tree
+    run_test "Non-existent directory exit code" "$TREE_BINARY /non/existent/path" "" "true"
+}
+
+test_depth_and_structure() {
+    log "Testing depth and structure options..."
+    
+    run_test "Depth level 1" "$TREE_BINARY -L 1 ." "dir1"
+    run_test "Depth level 2" "$TREE_BINARY --level=2 ." "subdir1"
+    run_test "No indentation" "$TREE_BINARY -i ." ""
+    run_test "Full path" "$TREE_BINARY -f ." "./"
+    run_test "ASCII characters" "$TREE_BINARY -A ." ""
+}
+
+test_file_filtering() {
+    log "Testing file filtering options..."
+    
+    run_test "All files (including hidden)" "$TREE_BINARY -a ." ".hidden"
+    run_test "Directories only" "$TREE_BINARY -d ." "dir1"
+    run_test "Pattern include .txt files" "$TREE_BINARY -P '*.txt' ." "file1.txt"
+    run_test "Pattern exclude .log files" "$TREE_BINARY -I '*.log' ." ""
+    run_test "File limit" "$TREE_BINARY --filelimit=5 ." ""
+}
+
+test_display_options() {
+    log "Testing display options..."
+    
+    run_test "Show file sizes" "$TREE_BINARY -s ." ""
+    run_test "Human readable sizes" "$TREE_BINARY -H ." ""
+    run_test "Color output" "$TREE_BINARY -C ." ""
+    run_test "No color output" "$TREE_BINARY -n ." ""
+    run_test "File type indicators" "$TREE_BINARY -F ." ""
+    run_test "Show permissions" "$TREE_BINARY -p ." ""
+    run_test "Show modification dates" "$TREE_BINARY -D ." ""
+}
+
+test_sorting_options() {
+    log "Testing sorting options..."
+    
+    run_test "Sort by time" "$TREE_BINARY -t ." ""
+    run_test "Reverse sort" "$TREE_BINARY -r ." ""
+    run_test "Directories first" "$TREE_BINARY --dirsfirst ." ""
+    run_test "No report" "$TREE_BINARY --noreport ." ""
+}
+
+test_output_options() {
+    log "Testing output options..."
+    
+    OUTPUT_FILE="/tmp/test_output.txt"
+    run_test "Output to file" "$TREE_BINARY -o $OUTPUT_FILE ." ""
+    
+    if [ -f "$OUTPUT_FILE" ]; then
+        if [ -s "$OUTPUT_FILE" ]; then
+            log_result "PASS" "Output file created and has content"
+        else
+            log_result "FAIL" "Output file created but is empty"
+        fi
+        rm -f "$OUTPUT_FILE"
+    else
+        log_result "FAIL" "Output file was not created"
+    fi
+}
+
+test_fromfile_functionality() {
+    log "Testing fromfile functionality..."
+    
+    # Create a simple file listing
+    cat > /tmp/file_list.txt << 'EOF'
+dir1/
+dir1/file1.txt
+dir2/
+file1.txt
+file2.txt
+EOF
+    
+    run_test "Read from file" "$TREE_BINARY --fromfile /tmp/file_list.txt" "dir1"
+    
+    # Test reading from stdin
+    run_test "Read from stdin" "echo -e 'test/\\ntest/file.txt' | $TREE_BINARY --fromfile" "test"
+    
+    rm -f /tmp/file_list.txt
+}
+
+test_combined_options() {
+    log "Testing combined options..."
+    
+    run_test "Multiple flags combination" "$TREE_BINARY -f -s -L 2 ." ""
+    run_test "Long flags combination" "$TREE_BINARY --full-path --size --level=2 ." ""
+    run_test "Pattern with exclusion" "$TREE_BINARY -P '*.txt' -I 'large*' ." ""
+}
+
+test_error_conditions() {
+    log "Testing error conditions..."
+    
+    run_test "Invalid flag" "$TREE_BINARY --invalid-flag ." "" "true"
+    run_test "Invalid level value" "$TREE_BINARY -L abc ." "" "true"
+    run_test "Invalid file limit" "$TREE_BINARY --filelimit=-1 ." "" "true"
+}
+
+print_summary() {
+    log ""
+    log "========================================="
+    log "QA Test Summary"
+    log "========================================="
+    log "Platform: $(uname -a)"
+    log "Rust version: $(rustc --version)"
+    log "Total tests: $TOTAL_TESTS"
+    log "Passed: $PASSED_TESTS"
+    log "Failed: $FAILED_TESTS"
+    if [ $TOTAL_TESTS -gt 0 ]; then
+        log "Success rate: $(( PASSED_TESTS * 100 / TOTAL_TESTS ))%"
+    fi
+    log "========================================="
+    
+    if [ $FAILED_TESTS -gt 0 ]; then
+        exit 1
+    fi
+}
+
+main() {
+    log "Starting QA tests for tree CLI (Docker container)"
+    log "Platform: $(uname -a)"
+    log "Date: $(date)"
+    log ""
+    
+    # Build the binary
+    if ! build_binary; then
+        log "Failed to build binary, exiting"
+        exit 1
+    fi
+    
+    # Setup test environment
+    setup_test_environment
+    
+    # Run all test suites
+    test_basic_functionality
+    test_depth_and_structure
+    test_file_filtering
+    test_display_options
+    test_sorting_options
+    test_output_options
+    test_fromfile_functionality
+    test_combined_options
+    test_error_conditions
+    
+    # Print summary
+    print_summary
+}
+
+# Run main function
+main "$@"

--- a/tests/qa/qa-test.sh
+++ b/tests/qa/qa-test.sh
@@ -1,0 +1,320 @@
+#!/bin/bash
+
+# Docker-based QA Test Orchestrator for Tree CLI
+# Runs comprehensive tests across multiple platforms using Docker containers
+
+set -e
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Configuration
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+QA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEMP_DIR="$QA_DIR/temp"
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+
+# Test platforms
+PLATFORMS=("linux" "alpine")
+SELECTED_PLATFORMS=()
+
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo ""
+    echo "Docker-based QA testing for tree CLI across multiple platforms"
+    echo ""
+    echo "Options:"
+    echo "  --all           Run tests on all platforms (linux, alpine)"
+    echo "  --linux         Run tests on Ubuntu Linux"
+    echo "  --alpine        Run tests on Alpine Linux"
+    echo "  --windows       Run tests on Windows (requires Windows Docker)"
+    echo "  --clean         Clean up Docker images and containers"
+    echo "  --logs          Show test logs directory"
+    echo "  --help, -h      Show this help message"
+    echo ""
+    echo "Examples:"
+    echo "  $0                          # Test all platforms (default)"
+    echo "  $0 --linux --alpine        # Test specific platforms"
+    echo "  $0 --all                   # Explicitly test all platforms"
+    echo "  $0 --clean                 # Clean up Docker resources"
+    echo ""
+}
+
+log() {
+    echo -e "${BLUE}[$(date '+%H:%M:%S')]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[$(date '+%H:%M:%S')] ✓${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[$(date '+%H:%M:%S')] ✗${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[$(date '+%H:%M:%S')] ⚠${NC} $1"
+}
+
+cleanup_docker() {
+    log "Cleaning up Docker resources..."
+    
+    # Remove containers
+    for platform in "${PLATFORMS[@]}" "windows"; do
+        container_name="tree-qa-$platform"
+        if docker ps -a --format "table {{.Names}}" | grep -q "^$container_name$"; then
+            log "Removing container: $container_name"
+            docker rm -f "$container_name" >/dev/null 2>&1 || true
+        fi
+    done
+    
+    # Remove images
+    for platform in "${PLATFORMS[@]}" "windows"; do
+        image_name="tree-qa:$platform"
+        if docker images --format "table {{.Repository}}:{{.Tag}}" | grep -q "^$image_name$"; then
+            log "Removing image: $image_name"
+            docker rmi "$image_name" >/dev/null 2>&1 || true
+        fi
+    done
+    
+    log_success "Docker cleanup completed"
+}
+
+build_docker_image() {
+    local platform="$1"
+    local dockerfile="Dockerfile.$platform"
+    local image_name="tree-qa:$platform"
+    
+    log "Building Docker image for $platform..."
+    
+    if ! docker build -t "$image_name" -f "$QA_DIR/$dockerfile" "$PROJECT_ROOT"; then
+        log_error "Failed to build Docker image for $platform"
+        return 1
+    fi
+    
+    log_success "Built Docker image: $image_name"
+    return 0
+}
+
+run_platform_test() {
+    local platform="$1"
+    local image_name="tree-qa:$platform"
+    local container_name="tree-qa-$platform-$TIMESTAMP"
+    local log_file="$TEMP_DIR/qa-$platform-$TIMESTAMP.log"
+    
+    # Ensure temp directory exists
+    mkdir -p "$TEMP_DIR"
+    
+    log "Running QA tests for $platform..."
+    
+    # Run the container
+    if docker run --name "$container_name" --rm "$image_name" > "$log_file" 2>&1; then
+        log_success "QA tests passed for $platform"
+        
+        # Show summary from log
+        if grep -q "QA Test Summary" "$log_file"; then
+            echo ""
+            echo -e "${BLUE}=== $platform Test Summary ===${NC}"
+            grep -A 10 "QA Test Summary" "$log_file" | head -10
+            echo ""
+        fi
+        
+        return 0
+    else
+        log_error "QA tests failed for $platform"
+        log_error "Check log file: $log_file"
+        
+        # Show last few lines of log for immediate debugging
+        echo ""
+        echo -e "${RED}=== Last 10 lines of $platform test log ===${NC}"
+        tail -10 "$log_file"
+        echo ""
+        
+        return 1
+    fi
+}
+
+run_windows_test() {
+    local platform="windows"
+    local image_name="tree-qa:$platform"
+    local container_name="tree-qa-$platform-$TIMESTAMP"
+    local log_file="$TEMP_DIR/qa-$platform-$TIMESTAMP.log"
+    
+    # Check if we're on Windows or have Windows containers enabled
+    if ! docker system info | grep -q "OSType.*windows"; then
+        log_warning "Windows containers not available. Skipping Windows tests."
+        log_warning "To run Windows tests, use a Windows Docker host or enable Windows containers."
+        return 0
+    fi
+    
+    # Ensure temp directory exists
+    mkdir -p "$TEMP_DIR"
+    
+    log "Building Docker image for Windows..."
+    if ! docker build -t "$image_name" -f "$QA_DIR/Dockerfile.windows" "$PROJECT_ROOT"; then
+        log_error "Failed to build Docker image for Windows"
+        return 1
+    fi
+    
+    log "Running QA tests for Windows..."
+    
+    # Run the container
+    if docker run --name "$container_name" --rm "$image_name" > "$log_file" 2>&1; then
+        log_success "QA tests passed for Windows"
+        
+        # Show summary from log
+        if grep -q "QA Test Summary" "$log_file"; then
+            echo ""
+            echo -e "${BLUE}=== Windows Test Summary ===${NC}"
+            grep -A 10 "QA Test Summary" "$log_file" | head -10
+            echo ""
+        fi
+        
+        return 0
+    else
+        log_error "QA tests failed for Windows"
+        log_error "Check log file: $log_file"
+        
+        # Show last few lines of log for immediate debugging
+        echo ""
+        echo -e "${RED}=== Last 10 lines of Windows test log ===${NC}"
+        tail -10 "$log_file"
+        echo ""
+        
+        return 1
+    fi
+}
+
+main() {
+    local run_all=false
+    local run_windows=false
+    local do_cleanup=false
+    local show_logs=false
+    
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --all)
+                run_all=true
+                shift
+                ;;
+            --linux)
+                SELECTED_PLATFORMS+=("linux")
+                shift
+                ;;
+            --alpine)
+                SELECTED_PLATFORMS+=("alpine")
+                shift
+                ;;
+            --windows)
+                run_windows=true
+                shift
+                ;;
+            --clean)
+                do_cleanup=true
+                shift
+                ;;
+            --logs)
+                show_logs=true
+                shift
+                ;;
+            --help|-h)
+                usage
+                exit 0
+                ;;
+            *)
+                echo "Unknown option: $1"
+                usage
+                exit 1
+                ;;
+        esac
+    done
+    
+    # Handle special commands
+    if [ "$do_cleanup" = true ]; then
+        cleanup_docker
+        exit 0
+    fi
+    
+    if [ "$show_logs" = true ]; then
+        echo "Test temp directory: $TEMP_DIR"
+        if [ -d "$TEMP_DIR" ]; then
+            echo "Available files:"
+            ls -la "$TEMP_DIR"
+        else
+            echo "No temp directory found."
+        fi
+        exit 0
+    fi
+    
+    # Determine which platforms to test
+    if [ "$run_all" = true ]; then
+        SELECTED_PLATFORMS=("${PLATFORMS[@]}")
+    fi
+    
+    # Default to running all platforms if none specified
+    if [ ${#SELECTED_PLATFORMS[@]} -eq 0 ] && [ "$run_windows" = false ]; then
+        SELECTED_PLATFORMS=("${PLATFORMS[@]}")
+        log "No specific platforms selected, running all platforms by default"
+    fi
+    
+    log "Starting Docker-based QA testing for tree CLI"
+    log "Timestamp: $TIMESTAMP"
+    log "Project root: $PROJECT_ROOT"
+    log "Temp directory: $TEMP_DIR"
+    echo ""
+    
+    # Ensure we're in the right directory
+    cd "$PROJECT_ROOT"
+    
+    # Test selected platforms
+    local overall_success=true
+    
+    for platform in "${SELECTED_PLATFORMS[@]}"; do
+        echo ""
+        log "=== Testing platform: $platform ==="
+        
+        if ! build_docker_image "$platform"; then
+            overall_success=false
+            continue
+        fi
+        
+        if ! run_platform_test "$platform"; then
+            overall_success=false
+        fi
+    done
+    
+    # Test Windows if requested
+    if [ "$run_windows" = true ]; then
+        echo ""
+        log "=== Testing platform: Windows ==="
+        
+        if ! run_windows_test; then
+            overall_success=false
+        fi
+    fi
+    
+    # Final summary
+    echo ""
+    echo "========================================"
+    if [ "$overall_success" = true ]; then
+        log_success "All QA tests completed successfully!"
+    else
+        log_error "Some QA tests failed. Check individual platform logs."
+    fi
+    
+    echo ""
+    log "Test logs available in: $TEMP_DIR"
+    echo "========================================"
+    
+    if [ "$overall_success" = false ]; then
+        exit 1
+    fi
+}
+
+# Run main function
+main "$@"


### PR DESCRIPTION
This adds Docker-based QA test tooling to validate `tree` functionality directly using the generated binaries - and not via code. Attempts to ensure feature parity and compatibility with standard Unix tree commands.

I'll consider addition to ci/cd release pipeline if proves valuable. For now, running this manually should be a pre-requisite for releases.