### PR TITLE
Fix --fromfile Windows path parsing

### DIFF
--- a/src/rust_tree/fromfile.rs
+++ b/src/rust_tree/fromfile.rs
@@ -104,13 +104,18 @@ fn detect_format(lines: &[String]) -> Option<FileListFormat> {
         .iter()
         .take(10)
         .filter(|line| {
-            // unzip -l format: has "Archive:" header or dashed separators
-            line.starts_with("Archive:")
-                || line.starts_with("---------")
-                || (line.contains(" ")
+            line.starts_with("Archive:") || line.starts_with("---------") || {
+                // Skip Windows paths (drive letter pattern X:)
+                if line.len() >= 2 && line.chars().nth(1) == Some(':') {
+                    return false;
+                }
+                // ZIP entry lines: indented with size as first field
+                let trimmed = line.trim_start();
+                line.len() > 40
                     && line.contains(":")
-                    && line.len() > 40
-                    && line.split_whitespace().count() >= 4)
+                    && line.split_whitespace().count() >= 4
+                    && trimmed.chars().next().is_some_and(|c| c.is_ascii_digit())
+            }
         })
         .count();
 

--- a/tests/fromfile_formats_tests.rs
+++ b/tests/fromfile_formats_tests.rs
@@ -342,3 +342,40 @@ fn test_file_entry_directory_inference() {
     assert!(has_integration);
     assert!(has_http);
 }
+
+#[test]
+fn test_windows_paths_with_spaces_not_detected_as_zip() {
+    // Regression test for issue #39
+    // Windows paths with multiple spaces should not be detected as ZIP format
+    let windows_paths = vec![
+        r"C:\Windows\Temp\dir dir dir\directory directory".to_string(),
+        r"D:\Program Files\My App\data files\config.txt".to_string(),
+        r"E:\Users\John Doe\Documents\My Documents\file.txt".to_string(),
+    ];
+
+    let entries = parse_file_listing(windows_paths);
+
+    // Should be parsed as simple paths, not ZIP
+    // Windows drive letters get normalized (C: -> C)
+    assert!(!entries.is_empty());
+    assert!(entries.iter().any(|e| e.path.contains("dir dir dir")));
+    assert!(entries.iter().any(|e| e.path.contains("Program Files")));
+    assert!(entries.iter().any(|e| e.path.contains("John Doe")));
+}
+
+#[test]
+fn test_windows_path_with_multiple_space_segments() {
+    // Regression test for issue #39
+    // The specific case from the issue report
+    let path = vec![r"C:\Windows\Temp\dir dir dir\directory directory".to_string()];
+
+    let entries = parse_file_listing(path);
+
+    // Should produce entries, not an empty tree
+    assert!(!entries.is_empty());
+
+    // Should have the nested directory structure
+    let paths: Vec<&str> = entries.iter().map(|e| e.path.as_str()).collect();
+    assert!(paths.iter().any(|p| p.contains("dir dir dir")));
+    assert!(paths.iter().any(|p| p.contains("directory directory")));
+}


### PR DESCRIPTION
The `--fromfile` flag is currently bugged when receiving piped input on Windows (Windows paths with spaces are being incorrectly  detected as zip). This change adds guards to better support Windows paths.

Fixes #39