### PR TITLE
Support multiple --exclude patterns

### DIFF
--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -76,9 +76,9 @@ pub struct Cli {
     #[arg(
         short = 'I',
         long = "exclude",
-        help = "Do not list files that match the wild-card pattern."
+        help = "Do not list files that match the wild-card pattern. May be repeated."
     )]
-    pub exclude: Option<String>,
+    pub exclude: Vec<String>,
 
     #[arg(
         short = 'f',
@@ -172,11 +172,11 @@ pub fn cli_to_options(cli: &Cli) -> Result<TreeOptions, String> {
         .map(|pattern| parse_glob_pattern(pattern))
         .transpose()?;
 
-    let exclude_pattern: Option<Pattern> = cli
+    let exclude_patterns: Vec<Pattern> = cli
         .exclude
-        .as_ref()
+        .iter()
         .map(|pattern| parse_glob_pattern(pattern))
-        .transpose()?;
+        .collect::<Result<Vec<_>, _>>()?;
 
     Ok(TreeOptions {
         all_files: cli.all_files,
@@ -187,7 +187,7 @@ pub fn cli_to_options(cli: &Cli) -> Result<TreeOptions, String> {
         print_size: cli.print_size,
         human_readable: cli.human_readable,
         pattern_glob,
-        exclude_pattern,
+        exclude_patterns,
         color: cli.color,
         no_color: cli.no_color,
         ascii: cli.ascii,
@@ -258,7 +258,7 @@ mod tests {
             print_size: false,
             human_readable: false,
             pattern: None,
-            exclude: None,
+            exclude: vec![],
             full_path: false,
             color: false,
             no_color: false,
@@ -281,7 +281,7 @@ mod tests {
         assert!(options.level.is_none());
         assert!(!options.dir_only);
         assert!(options.pattern_glob.is_none());
-        assert!(options.exclude_pattern.is_none());
+        assert!(options.exclude_patterns.is_empty());
     }
 
     #[test]
@@ -295,7 +295,7 @@ mod tests {
             print_size: true,
             human_readable: true,
             pattern: Some("*.rs".to_string()),
-            exclude: Some("target".to_string()),
+            exclude: vec!["target".to_string()],
             full_path: true,
             color: true,
             no_color: false,
@@ -319,7 +319,7 @@ mod tests {
         assert!(options.print_size);
         assert!(options.human_readable);
         assert!(options.pattern_glob.is_some());
-        assert!(options.exclude_pattern.is_some());
+        assert!(!options.exclude_patterns.is_empty());
         assert!(options.full_path);
         assert!(options.color);
         assert!(options.ascii);
@@ -346,7 +346,7 @@ mod tests {
             print_size: false,
             human_readable: false,
             pattern: Some("[".to_string()), // Invalid pattern
-            exclude: None,
+            exclude: vec![],
             full_path: false,
             color: false,
             no_color: false,

--- a/src/rust_tree/options.rs
+++ b/src/rust_tree/options.rs
@@ -9,7 +9,7 @@ pub struct TreeOptions {
     pub print_size: bool,
     pub human_readable: bool,
     pub pattern_glob: Option<Pattern>,
-    pub exclude_pattern: Option<Pattern>,
+    pub exclude_patterns: Vec<Pattern>,
     pub color: bool,
     pub no_color: bool,
     pub ascii: bool,

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -98,8 +98,8 @@ fn should_skip_entry(
         return Ok(true);
     }
 
-    // Check exclude pattern FIRST
-    if let Some(exclude_pattern) = &options.exclude_pattern {
+    // Check exclude patterns FIRST
+    for exclude_pattern in &options.exclude_patterns {
         if file_name.is_some_and(|name| exclude_pattern.matches(name)) {
             return Ok(true);
         }
@@ -474,7 +474,7 @@ pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io
 ///     print_size: false,
 ///     human_readable: false,
 ///     pattern_glob: None,
-///     exclude_pattern: None,
+///     exclude_patterns: vec![],
 ///     color: false,
 ///     no_color: false,
 ///     ascii: false,
@@ -820,8 +820,8 @@ fn should_skip_virtual_entry(entry: &FileEntry, options: &TreeOptions) -> std::i
         return Ok(true);
     }
 
-    // Check exclude pattern
-    if let Some(exclude_pattern) = &options.exclude_pattern {
+    // Check exclude patterns
+    for exclude_pattern in &options.exclude_patterns {
         if exclude_pattern.matches(filename) {
             return Ok(true);
         }

--- a/tests/cli_unit_tests.rs
+++ b/tests/cli_unit_tests.rs
@@ -17,7 +17,7 @@ fn create_test_options() -> TreeOptions {
         print_size: true,
         human_readable: false,
         pattern_glob: Some(Pattern::new("*.rs").unwrap()),
-        exclude_pattern: Some(Pattern::new("target").unwrap()),
+        exclude_patterns: vec![Pattern::new("target").unwrap()],
         color: false,
         no_color: true,
         ascii: true,
@@ -48,7 +48,7 @@ fn test_tree_options_construction() {
     assert!(options.print_size);
     assert!(!options.human_readable);
     assert!(options.pattern_glob.is_some());
-    assert!(options.exclude_pattern.is_some());
+    assert!(!options.exclude_patterns.is_empty());
     assert!(!options.color);
     assert!(options.no_color);
     assert!(options.ascii);
@@ -75,7 +75,7 @@ fn test_tree_options_defaults() {
         print_size: false,
         human_readable: false,
         pattern_glob: None,
-        exclude_pattern: None,
+        exclude_patterns: vec![],
         color: false,
         no_color: false,
         ascii: false,
@@ -97,7 +97,7 @@ fn test_tree_options_defaults() {
     assert_eq!(options.level, None);
     assert!(!options.full_path);
     assert!(options.pattern_glob.is_none());
-    assert!(options.exclude_pattern.is_none());
+    assert!(options.exclude_patterns.is_empty());
     assert_eq!(options.output_file, None);
     assert_eq!(options.file_limit, None);
 }

--- a/tests/main_integration_tests.rs
+++ b/tests/main_integration_tests.rs
@@ -166,6 +166,33 @@ fn test_cli_exclude_pattern() {
 }
 
 #[test]
+fn test_cli_multiple_exclude_patterns() {
+    let temp_dir = tempdir().unwrap();
+    fs::write(temp_dir.path().join("keep.rs"), "keep").unwrap();
+    fs::write(temp_dir.path().join("ignore.txt"), "ignore").unwrap();
+    fs::write(temp_dir.path().join("skip.md"), "skip").unwrap();
+    fs::write(temp_dir.path().join("drop.log"), "drop").unwrap();
+
+    let mut cmd = Command::cargo_bin("tree").unwrap();
+    cmd.current_dir(temp_dir.path())
+        .arg("-I")
+        .arg("*.txt")
+        .arg("-I")
+        .arg("*.md")
+        .arg("-I")
+        .arg("*.log");
+
+    let output = cmd.output().unwrap();
+    assert!(output.status.success());
+
+    let stdout_str = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout_str.contains("keep.rs"));
+    assert!(!stdout_str.contains("ignore.txt"));
+    assert!(!stdout_str.contains("skip.md"));
+    assert!(!stdout_str.contains("drop.log"));
+}
+
+#[test]
 fn test_cli_ascii_mode() {
     let temp_dir = tempdir().unwrap();
     fs::create_dir(temp_dir.path().join("subdir")).unwrap();

--- a/tests/traversal_tests.rs
+++ b/tests/traversal_tests.rs
@@ -41,7 +41,7 @@ fn create_default_options() -> TreeOptions {
         print_size: false,
         human_readable: false,
         pattern_glob: None,
-        exclude_pattern: None,
+        exclude_patterns: vec![],
         color: false,
         no_color: false,
         ascii: false,
@@ -95,7 +95,7 @@ fn test_list_directory_with_pattern() {
 fn test_list_directory_exclude_pattern() {
     let temp_dir = create_test_directory();
     let mut options = create_default_options();
-    options.exclude_pattern = Some(Pattern::new("target").unwrap());
+    options.exclude_patterns = vec![Pattern::new("target").unwrap()];
 
     // Test that exclude pattern works without error
     let result = list_directory(temp_dir.path(), &options);
@@ -357,7 +357,7 @@ fn test_exclude_pattern_combinations() {
 
     for pattern_str in exclude_patterns {
         let mut options = create_default_options();
-        options.exclude_pattern = Some(Pattern::new(pattern_str).unwrap());
+        options.exclude_patterns = vec![Pattern::new(pattern_str).unwrap()];
         options.all_files = true;
 
         let result = list_directory(temp_dir.path(), &options);

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -18,7 +18,7 @@ fn create_basic_options() -> TreeOptions {
         print_size: false,
         human_readable: false,
         pattern_glob: None,
-        exclude_pattern: None,
+        exclude_patterns: vec![],
         color: false,
         no_color: false,
         ascii: false,
@@ -90,7 +90,7 @@ fn test_list_directory_with_patterns() {
     assert!(list_directory(temp_dir.path(), &options).is_ok());
 
     options.pattern_glob = None;
-    options.exclude_pattern = Some(Pattern::new("*.rs").unwrap());
+    options.exclude_patterns = vec![Pattern::new("*.rs").unwrap()];
     assert!(list_directory(temp_dir.path(), &options).is_ok());
 }
 


### PR DESCRIPTION
Allow specifying of multiple --exclude / -I patterns similar to other *nix `tree`s. Currently not supported.

`tree -I "*.txt" -I "*.md"`

Fixes #38