### PR TITLE
Add --prune to hide empty directories when filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Website: [https://peteretelej.github.io/tree/](https://peteretelej.github.io/tre
 - [x] Use ASCII characters for tree display (`-A` or `--ascii`)
 - [x] List directories only (`-d` or `--directories`)
 - [x] Exclude specific files matching patterns (`-I` or `--exclude`)
+- [x] Prune empty directories from output (`--prune`)
 - [x] Send output to filename with `-o` flag
 - [x] Do not descend directories that contain more than # entries with `--filelimit` flag
 - [x] List directories first before files with `dirsfirst` flag
@@ -97,6 +98,9 @@ For example:
 ./tree --level=2 .
 ./tree --all --full-path --size .
 ./tree --pattern="*.txt" --exclude="*.log" .
+
+# Hide directories that have no matching files
+./tree --pattern="*.txt" --exclude="*.log" --prune .
 ```
 
 ### Using as Rust Crate

--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -162,6 +162,12 @@ pub struct Cli {
         help = "Show icons for files and directories based on their type and extension."
     )]
     pub icons: bool,
+
+    #[arg(
+        long = "prune",
+        help = "Prune empty directories when using -P or -I. Has increased memory usage."
+    )]
+    pub prune: bool,
 }
 
 /// Convert CLI arguments to TreeOptions
@@ -202,6 +208,7 @@ pub fn cli_to_options(cli: &Cli) -> Result<TreeOptions, String> {
         print_permissions: cli.print_permissions,
         from_file: cli.fromfile,
         icons: cli.icons,
+        prune: cli.prune,
     })
 }
 
@@ -274,6 +281,7 @@ mod tests {
             print_permissions: false,
             fromfile: false,
             icons: false,
+            prune: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -311,6 +319,7 @@ mod tests {
             print_permissions: true,
             fromfile: true,
             icons: false,
+            prune: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -362,6 +371,7 @@ mod tests {
             print_permissions: false,
             fromfile: false,
             icons: false,
+            prune: false,
         };
 
         let result = cli_to_options(&cli);

--- a/src/rust_tree/options.rs
+++ b/src/rust_tree/options.rs
@@ -24,4 +24,5 @@ pub struct TreeOptions {
     pub print_permissions: bool,
     pub from_file: bool,
     pub icons: bool,
+    pub prune: bool,
 }

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -258,6 +258,10 @@ fn format_entry_line(
     Ok(line)
 }
 
+fn has_pattern_filter(options: &TreeOptions) -> bool {
+    options.pattern_glob.is_some() || !options.exclude_patterns.is_empty()
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn traverse_directory<P: AsRef<Path>, W: Write>(
     writer: &mut W,
@@ -268,7 +272,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
     stats: &mut (u64, u64),
     indent_state: &[bool],
     icon_manager: &IconManager,
-) -> std::io::Result<()> {
+) -> std::io::Result<bool> {
     // --- 1. Read and Pre-process Directory Entries ---
     let read_dir_result = fs::read_dir(current_path);
     let mut entries_info: Vec<EntryInfo> = match read_dir_result {
@@ -367,27 +371,21 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
     }
 
     // --- 4. Iterate, Print, Count Stats, and Recurse (conditionally) ---
+    let prune_mode = options.prune && has_pattern_filter(options);
+    let mut found_content = false;
+
     let last_index = entries_info.len().saturating_sub(1);
     for (index, info) in entries_info.into_iter().enumerate() {
         let entry = info.entry;
         let path = entry.path();
         let is_entry_last = index == last_index;
 
-        // Format and print the line for the current entry
-        let line = format_entry_line(&entry, options, indent_state, is_entry_last, icon_manager)?;
-        writeln!(writer, "{line}")?;
-
-        // Update stats and decide recursion based on entry type
         if entry.file_type()?.is_dir() {
-            stats.0 += 1; // Count this directory
-
             // --- Check limits specifically for this directory before recursion ---
             let mut skip_recursion = false;
 
             // 1. Check level limit for the *next* level
             if let Some(max_level) = options.level {
-                // If the next depth (depth + 1) is >= max_level, we should not recurse.
-                // Remember depth is 0-indexed, max_level is 1-indexed.
                 if (depth + 1) >= max_level as usize {
                     skip_recursion = true;
                 }
@@ -397,18 +395,13 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
             if !skip_recursion {
                 if let Some(limit) = options.file_limit {
                     match fs::read_dir(&path) {
-                        // Read the *child* directory (`path`) to count its entries
                         Ok(reader) => {
-                            // Use iterator `count()` for efficiency.
-                            // This counts *raw* entries, matching standard `tree --filelimit` behavior.
                             let entry_count = reader.count();
                             if entry_count > limit as usize {
                                 skip_recursion = true;
-                                // Optionally: Add indicator like "[...]" to the printed line if skipped?
                             }
                         }
                         Err(e) => {
-                            // If we can't read the directory to check the limit, log warning but don't skip.
                             eprintln!(
                                 "Warning: Could not read directory {path:?} to check filelimit: {e}"
                             );
@@ -416,30 +409,78 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                     }
                 }
             }
-            // --- End limit checks ---
 
-            if !skip_recursion {
-                // Recurse only if no limits apply
+            if prune_mode {
+                // In prune mode: recurse first to check if directory has content
+                let mut child_buffer: Vec<u8> = Vec::new();
+                let mut child_stats = (0u64, 0u64);
                 let mut next_indent_state = indent_state.to_vec();
                 next_indent_state.push(is_entry_last);
-                traverse_directory(
-                    writer,
-                    root_path.as_ref(),
-                    &path, // Recurse into the child directory `path`
-                    options,
-                    depth + 1,
-                    stats,
-                    &next_indent_state,
-                    icon_manager,
-                )?;
+
+                let has_content = if skip_recursion {
+                    false
+                } else {
+                    traverse_directory(
+                        &mut child_buffer,
+                        root_path.as_ref(),
+                        &path,
+                        options,
+                        depth + 1,
+                        &mut child_stats,
+                        &next_indent_state,
+                        icon_manager,
+                    )?
+                };
+
+                if has_content {
+                    // Directory has matching content, include it
+                    let line = format_entry_line(
+                        &entry,
+                        options,
+                        indent_state,
+                        is_entry_last,
+                        icon_manager,
+                    )?;
+                    writeln!(writer, "{line}")?;
+                    writer.write_all(&child_buffer)?;
+                    stats.0 += 1 + child_stats.0;
+                    stats.1 += child_stats.1;
+                    found_content = true;
+                }
+            } else {
+                // Normal mode: print directory then recurse
+                let line =
+                    format_entry_line(&entry, options, indent_state, is_entry_last, icon_manager)?;
+                writeln!(writer, "{line}")?;
+                stats.0 += 1;
+                found_content = true;
+
+                if !skip_recursion {
+                    let mut next_indent_state = indent_state.to_vec();
+                    next_indent_state.push(is_entry_last);
+                    traverse_directory(
+                        writer,
+                        root_path.as_ref(),
+                        &path,
+                        options,
+                        depth + 1,
+                        stats,
+                        &next_indent_state,
+                        icon_manager,
+                    )?;
+                }
             }
         } else {
-            // It's a file
-            stats.1 += 1; // Count this file
+            // It's a file - always print (already passed filter)
+            let line =
+                format_entry_line(&entry, options, indent_state, is_entry_last, icon_manager)?;
+            writeln!(writer, "{line}")?;
+            stats.1 += 1;
+            found_content = true;
         }
     }
 
-    Ok(())
+    Ok(found_content)
 }
 
 pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io::Result<()> {
@@ -489,6 +530,7 @@ pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io
 ///     print_permissions: false,
 ///     from_file: false,
 ///     icons: false,
+///     prune: false,
 /// };
 /// let tree_output = list_directory_as_string(".", &options).unwrap();
 /// println!("{}", tree_output);
@@ -688,52 +730,95 @@ fn display_virtual_entries<W: Write>(
     indent_state: &[bool],
     depth: usize,
     icon_manager: &IconManager,
-) -> std::io::Result<()> {
+) -> std::io::Result<bool> {
     // Check level limit
     if let Some(max_level) = options.level {
         if depth >= max_level as usize {
-            return Ok(());
+            return Ok(false);
         }
     }
+
+    let prune_mode = options.prune && has_pattern_filter(options);
+    let mut found_content = false;
 
     for (i, entry) in entries.iter().enumerate() {
         let is_last = i == entries.len() - 1;
 
-        // Apply filters
-        if should_skip_virtual_entry(entry, options)? {
+        // Apply filters (but directories pass through for now if pruning)
+        let should_skip = should_skip_virtual_entry(entry, options)?;
+        if should_skip && (!entry.is_dir || !prune_mode) {
             continue;
         }
 
-        // Update stats
         if entry.is_dir {
-            stats.0 += 1;
-        } else {
-            stats.1 += 1;
-        }
-
-        // Display entry
-        display_virtual_entry(writer, entry, options, indent_state, is_last, icon_manager)?;
-
-        // Recurse into directories
-        if entry.is_dir {
-            if let Some(children) = all_children.get(&entry.path) {
+            if prune_mode {
+                // In prune mode: check if directory has content first
+                let mut child_buffer: Vec<u8> = Vec::new();
+                let mut child_stats = (0u32, 0u32);
                 let mut new_indent_state = indent_state.to_vec();
                 new_indent_state.push(!is_last);
-                display_virtual_entries(
-                    writer,
-                    children,
-                    all_children,
-                    options,
-                    stats,
-                    &new_indent_state,
-                    depth + 1,
-                    icon_manager,
-                )?;
+
+                let has_content = if let Some(children) = all_children.get(&entry.path) {
+                    display_virtual_entries(
+                        &mut child_buffer,
+                        children,
+                        all_children,
+                        options,
+                        &mut child_stats,
+                        &new_indent_state,
+                        depth + 1,
+                        icon_manager,
+                    )?
+                } else {
+                    false
+                };
+
+                if has_content {
+                    display_virtual_entry(
+                        writer,
+                        entry,
+                        options,
+                        indent_state,
+                        is_last,
+                        icon_manager,
+                    )?;
+                    writer.write_all(&child_buffer)?;
+                    stats.0 += 1 + child_stats.0;
+                    stats.1 += child_stats.1;
+                    found_content = true;
+                }
+            } else {
+                // Normal mode
+                stats.0 += 1;
+                display_virtual_entry(writer, entry, options, indent_state, is_last, icon_manager)?;
+                found_content = true;
+
+                if let Some(children) = all_children.get(&entry.path) {
+                    let mut new_indent_state = indent_state.to_vec();
+                    new_indent_state.push(!is_last);
+                    display_virtual_entries(
+                        writer,
+                        children,
+                        all_children,
+                        options,
+                        stats,
+                        &new_indent_state,
+                        depth + 1,
+                        icon_manager,
+                    )?;
+                }
+            }
+        } else {
+            // File - display if it passed filter
+            if !should_skip {
+                stats.1 += 1;
+                display_virtual_entry(writer, entry, options, indent_state, is_last, icon_manager)?;
+                found_content = true;
             }
         }
     }
 
-    Ok(())
+    Ok(found_content)
 }
 
 fn display_virtual_entry<W: Write>(

--- a/tests/cli_unit_tests.rs
+++ b/tests/cli_unit_tests.rs
@@ -32,6 +32,7 @@ fn create_test_options() -> TreeOptions {
         print_permissions: false,
         from_file: false,
         icons: false,
+        prune: false,
     }
 }
 
@@ -90,6 +91,7 @@ fn test_tree_options_defaults() {
         print_permissions: false,
         from_file: false,
         icons: false,
+        prune: false,
     };
 
     // Test default values

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -405,6 +405,86 @@ fn test_fromfile_with_flags() {
 }
 
 #[test]
+fn test_fromfile_prune_with_pattern() {
+    let paths = "empty_dir/\nhas_txt/\nhas_txt/file.txt\nhas_txt/subdir/\nhas_txt/subdir/nested.txt\nno_txt/\nno_txt/file.rs\n";
+
+    let output = cmd()
+        .args(["--fromfile", "--prune", "--pattern", "*.txt", "."])
+        .write_stdin(paths)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert!(output_contains(&output, "has_txt"));
+    assert!(output_contains(&output, "file.txt"));
+    assert!(output_contains(&output, "subdir"));
+    assert!(output_contains(&output, "nested.txt"));
+    assert!(output_not_contains(&output, "empty_dir"));
+    assert!(output_not_contains(&output, "no_txt"));
+    assert!(output_not_contains(&output, "file.rs"));
+}
+
+#[test]
+fn test_fromfile_prune_with_exclude() {
+    let paths = "logs/\nlogs/app.log\nlogs/error.log\ndata/\ndata/config.txt\ndata/cache.log\n";
+
+    let output = cmd()
+        .args(["--fromfile", "--prune", "--exclude", "*.log", "."])
+        .write_stdin(paths)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert!(output_contains(&output, "data"));
+    assert!(output_contains(&output, "config.txt"));
+    assert!(output_not_contains(&output, "logs"));
+    assert!(output_not_contains(&output, "app.log"));
+}
+
+#[test]
+fn test_fromfile_prune_nested() {
+    let paths = "a/\na/b/\na/b/c/\na/b/c/d/\na/b/c/d/deep.txt\nempty/\n";
+
+    let output = cmd()
+        .args(["--fromfile", "--prune", "--pattern", "*.txt", "."])
+        .write_stdin(paths)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert!(output_contains(&output, "a"));
+    assert!(output_contains(&output, "b"));
+    assert!(output_contains(&output, "c"));
+    assert!(output_contains(&output, "d"));
+    assert!(output_contains(&output, "deep.txt"));
+    assert!(output_not_contains(&output, "empty"));
+}
+
+#[test]
+fn test_fromfile_prune_without_filter() {
+    let paths = "empty_dir/\nhas_files/\nhas_files/file.txt\n";
+
+    let output = cmd()
+        .args(["--fromfile", "--prune", "."])
+        .write_stdin(paths)
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+
+    assert!(output_contains(&output, "empty_dir"));
+    assert!(output_contains(&output, "has_files"));
+    assert!(output_contains(&output, "file.txt"));
+}
+
+#[test]
 fn test_error_handling() {
     // Test with non-existent directory - should fail with non-zero exit code
     let nonexistent_path = if cfg!(windows) {

--- a/tests/traversal_tests.rs
+++ b/tests/traversal_tests.rs
@@ -56,6 +56,7 @@ fn create_default_options() -> TreeOptions {
         print_permissions: false,
         from_file: false,
         icons: false,
+        prune: false,
     }
 }
 
@@ -578,4 +579,119 @@ fn test_list_directory_as_string_nonexistent_path() {
 
     let result = list_directory_as_string(nonexistent_path, &options);
     assert!(result.is_err());
+}
+
+fn create_prune_test_directory() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    fs::create_dir(temp_path.join("empty_dir")).unwrap();
+    fs::create_dir(temp_path.join("has_txt")).unwrap();
+    fs::create_dir(temp_path.join("has_txt").join("subdir")).unwrap();
+    fs::create_dir(temp_path.join("no_txt")).unwrap();
+
+    fs::write(temp_path.join("has_txt").join("file.txt"), "content").unwrap();
+    fs::write(
+        temp_path.join("has_txt").join("subdir").join("nested.txt"),
+        "nested",
+    )
+    .unwrap();
+    fs::write(temp_path.join("no_txt").join("file.rs"), "fn main() {}").unwrap();
+
+    temp_dir
+}
+
+#[test]
+fn test_prune_with_pattern() {
+    let temp_dir = create_prune_test_directory();
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("*.txt").unwrap());
+    options.prune = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    assert!(output.contains("has_txt"), "Should contain has_txt dir");
+    assert!(output.contains("file.txt"), "Should contain file.txt");
+    assert!(output.contains("subdir"), "Should contain subdir");
+    assert!(output.contains("nested.txt"), "Should contain nested.txt");
+
+    assert!(
+        !output.contains("empty_dir"),
+        "Should not contain empty_dir"
+    );
+    assert!(!output.contains("no_txt"), "Should not contain no_txt dir");
+    assert!(!output.contains("file.rs"), "Should not contain file.rs");
+}
+
+#[test]
+fn test_prune_with_exclude() {
+    let temp_dir = create_prune_test_directory();
+    let mut options = create_default_options();
+    options.exclude_patterns = vec![Pattern::new("*.txt").unwrap()];
+    options.prune = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    assert!(output.contains("no_txt"), "Should contain no_txt dir");
+    assert!(output.contains("file.rs"), "Should contain file.rs");
+
+    assert!(
+        !output.contains("empty_dir"),
+        "Should not contain empty_dir"
+    );
+    assert!(
+        !output.contains("has_txt"),
+        "Should not contain has_txt (all content excluded)"
+    );
+}
+
+#[test]
+fn test_prune_without_filter_has_no_effect() {
+    let temp_dir = create_prune_test_directory();
+    let mut options = create_default_options();
+    options.prune = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    assert!(
+        output.contains("empty_dir"),
+        "Should contain empty_dir (no filter active)"
+    );
+    assert!(output.contains("has_txt"), "Should contain has_txt");
+    assert!(output.contains("no_txt"), "Should contain no_txt");
+}
+
+#[test]
+fn test_prune_nested_directories() {
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    fs::create_dir_all(temp_path.join("a").join("b").join("c")).unwrap();
+    fs::write(
+        temp_path.join("a").join("b").join("c").join("deep.txt"),
+        "deep",
+    )
+    .unwrap();
+    fs::create_dir(temp_path.join("empty")).unwrap();
+
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("*.txt").unwrap());
+    options.prune = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    assert!(output.contains("deep.txt"), "Should contain deep.txt");
+    assert!(!output.contains("empty"), "Should not contain empty dir");
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -33,6 +33,7 @@ fn create_basic_options() -> TreeOptions {
         print_permissions: false,
         from_file: false,
         icons: false,
+        prune: false,
     }
 }
 


### PR DESCRIPTION
When using `--pattern` or `--exclude`, `tree` returns empty directories in the listing. This is a bug in the linux tree https://linux.die.net/man/1/tree. Arch Linux's tree supports `--prune` to allow exclusion of such empty directories as documented here: https://man.archlinux.org/man/tree.1.en#BUGS_AND_NOTES

This change adds similar functionality.

```
# --prune will hide empty directories
./tree --pattern="*.txt" --exclude="*.log" --prune .
```

Resolves #36 