### PR TITLE
Add --matchdirs support in -P pattern matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Website: [https://peteretelej.github.io/tree/](https://peteretelej.github.io/tre
 - [x] List directories only (`-d` or `--directories`)
 - [x] Exclude specific files matching patterns (`-I` or `--exclude`)
 - [x] Prune directories with no matching files when -P or -I is used (`--prune`)
+- [x] Apply -P pattern to directory names (`--matchdirs`)
 - [x] Send output to filename with `-o` flag
 - [x] Do not descend directories that contain more than # entries with `--filelimit` flag
 - [x] List directories first before files with `dirsfirst` flag
@@ -80,10 +81,11 @@ rustup default stable
 
 ## Usage
 
-## Usage
-
 ```sh
 ./tree [FLAGS] [OPTIONS] [PATH]
+
+# Get help and see all available options
+./tree --help
 ```
 
 For example:

--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -168,6 +168,12 @@ pub struct Cli {
         help = "Prune directories with no matching files when using -P or -I. Has increased memory usage."
     )]
     pub prune: bool,
+
+    #[arg(
+        long = "matchdirs",
+        help = "Include directory names in -P pattern matching. Matched directories show all contents."
+    )]
+    pub match_dirs: bool,
 }
 
 /// Convert CLI arguments to TreeOptions
@@ -193,6 +199,7 @@ pub fn cli_to_options(cli: &Cli) -> Result<TreeOptions, String> {
         print_size: cli.print_size,
         human_readable: cli.human_readable,
         pattern_glob,
+        match_dirs: cli.match_dirs,
         exclude_patterns,
         color: cli.color,
         no_color: cli.no_color,
@@ -282,6 +289,7 @@ mod tests {
             fromfile: false,
             icons: false,
             prune: false,
+            match_dirs: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -320,6 +328,7 @@ mod tests {
             fromfile: true,
             icons: false,
             prune: false,
+            match_dirs: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -372,6 +381,7 @@ mod tests {
             fromfile: false,
             icons: false,
             prune: false,
+            match_dirs: false,
         };
 
         let result = cli_to_options(&cli);

--- a/src/rust_tree/options.rs
+++ b/src/rust_tree/options.rs
@@ -9,6 +9,7 @@ pub struct TreeOptions {
     pub print_size: bool,
     pub human_readable: bool,
     pub pattern_glob: Option<Pattern>,
+    pub match_dirs: bool,
     pub exclude_patterns: Vec<Pattern>,
     pub color: bool,
     pub no_color: bool,

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -87,7 +87,7 @@ fn format_date(time: SystemTime) -> String {
 fn should_skip_entry(
     entry: &fs::DirEntry,
     options: &TreeOptions,
-    _depth: usize,
+    depth: usize,
 ) -> std::io::Result<bool> {
     let path = entry.path();
     let file_name = path.file_name().and_then(|name| name.to_str());
@@ -107,8 +107,22 @@ fn should_skip_entry(
 
     // Check include pattern (only if exclude didn't match)
     if let Some(pattern) = &options.pattern_glob {
-        if !path.is_dir() && !file_name.is_some_and(|name| pattern.matches(name)) {
-            return Ok(true);
+        // Directories are never filtered by pattern
+        if !path.is_dir() {
+            // In matchdirs mode, files at depth 1 (inside depth-0 dirs) with matching parent
+            // are shown without filtering. depth==1 means parent dir is at depth 0 (direct child of root)
+            let parent_is_depth1_match = options.match_dirs
+                && depth == 1
+                && path
+                    .parent()
+                    .and_then(|p| p.file_name())
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|parent_name| pattern.matches(parent_name));
+
+            // Show file if: parent matched at depth 1 OR file matches pattern
+            if !parent_is_depth1_match && !file_name.is_some_and(|name| pattern.matches(name)) {
+                return Ok(true);
+            }
         }
     }
 
@@ -432,7 +446,16 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                     )?
                 };
 
-                if has_content {
+                // Check if this directory matches the pattern (for matchdirs mode)
+                let this_dir_matches = options.match_dirs
+                    && options.pattern_glob.as_ref().is_some_and(|pattern| {
+                        path.file_name()
+                            .and_then(|n| n.to_str())
+                            .is_some_and(|name| pattern.matches(name))
+                    });
+
+                // Include if has content OR directory matched pattern (don't prune matched dirs)
+                if has_content || this_dir_matches {
                     // Directory has matching content, include it
                     let line = format_entry_line(
                         &entry,
@@ -515,6 +538,7 @@ pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io
 ///     print_size: false,
 ///     human_readable: false,
 ///     pattern_glob: None,
+///     match_dirs: false,
 ///     exclude_patterns: vec![],
 ///     color: false,
 ///     no_color: false,
@@ -745,7 +769,7 @@ fn display_virtual_entries<W: Write>(
         let is_last = i == entries.len() - 1;
 
         // Apply filters (but directories pass through for now if pruning)
-        let should_skip = should_skip_virtual_entry(entry, options)?;
+        let should_skip = should_skip_virtual_entry(entry, options, depth)?;
         if should_skip && (!entry.is_dir || !prune_mode) {
             continue;
         }
@@ -773,7 +797,20 @@ fn display_virtual_entries<W: Write>(
                     false
                 };
 
-                if has_content {
+                // Check if this directory matches the pattern (for matchdirs mode)
+                let filename = if let Some(pos) = entry.path.rfind('/') {
+                    &entry.path[pos + 1..]
+                } else {
+                    &entry.path
+                };
+                let this_dir_matches = options.match_dirs
+                    && options
+                        .pattern_glob
+                        .as_ref()
+                        .is_some_and(|pattern| pattern.matches(filename));
+
+                // Include if has content OR directory matched pattern (don't prune matched dirs)
+                if has_content || this_dir_matches {
                     display_virtual_entry(
                         writer,
                         entry,
@@ -892,7 +929,11 @@ fn display_virtual_entry<W: Write>(
     Ok(())
 }
 
-fn should_skip_virtual_entry(entry: &FileEntry, options: &TreeOptions) -> std::io::Result<bool> {
+fn should_skip_virtual_entry(
+    entry: &FileEntry,
+    options: &TreeOptions,
+    depth: usize,
+) -> std::io::Result<bool> {
     let filename = if let Some(pos) = entry.path.rfind('/') {
         &entry.path[pos + 1..]
     } else {
@@ -914,8 +955,29 @@ fn should_skip_virtual_entry(entry: &FileEntry, options: &TreeOptions) -> std::i
 
     // Check include pattern
     if let Some(include_pattern) = &options.pattern_glob {
-        if !include_pattern.matches(filename) {
-            return Ok(true);
+        // Directories are never filtered by pattern
+        if !entry.is_dir {
+            // In matchdirs mode, files at depth 1 (inside depth-0 dirs) with matching parent
+            // are shown without filtering
+            let parent_is_depth1_match = options.match_dirs && depth == 1 && {
+                // Get parent directory name from path
+                if let Some(slash_pos) = entry.path.rfind('/') {
+                    let parent_path = &entry.path[..slash_pos];
+                    let parent_name = if let Some(pos) = parent_path.rfind('/') {
+                        &parent_path[pos + 1..]
+                    } else {
+                        parent_path
+                    };
+                    include_pattern.matches(parent_name)
+                } else {
+                    false
+                }
+            };
+
+            // Show file if: parent matched at depth 1 OR file matches pattern
+            if !parent_is_depth1_match && !include_pattern.matches(filename) {
+                return Ok(true);
+            }
         }
     }
 

--- a/tests/cli_unit_tests.rs
+++ b/tests/cli_unit_tests.rs
@@ -33,6 +33,7 @@ fn create_test_options() -> TreeOptions {
         from_file: false,
         icons: false,
         prune: false,
+        match_dirs: false,
     }
 }
 
@@ -92,6 +93,7 @@ fn test_tree_options_defaults() {
         from_file: false,
         icons: false,
         prune: false,
+        match_dirs: false,
     };
 
     // Test default values

--- a/tests/traversal_tests.rs
+++ b/tests/traversal_tests.rs
@@ -57,6 +57,7 @@ fn create_default_options() -> TreeOptions {
         from_file: false,
         icons: false,
         prune: false,
+        match_dirs: false,
     }
 }
 
@@ -694,4 +695,252 @@ fn test_prune_nested_directories() {
 
     assert!(output.contains("deep.txt"), "Should contain deep.txt");
     assert!(!output.contains("empty"), "Should not contain empty dir");
+}
+
+fn create_matchdirs_test_directory() -> tempfile::TempDir {
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create structure matching the plan's test case:
+    // fzf_root/init.lua        (depth 2, parent matches at depth 1)
+    // fzf_root/sub/nested.lua  (depth 3, parent doesn't match at depth 1)
+    // project/fzf/plugin.lua   (depth 3, fzf matches but at depth 2)
+    fs::create_dir_all(temp_path.join("fzf_root").join("sub").join("deep")).unwrap();
+    fs::create_dir_all(temp_path.join("project").join("fzf").join("sub")).unwrap();
+
+    fs::write(temp_path.join("fzf_root").join("init.lua"), "x").unwrap();
+    fs::write(
+        temp_path.join("fzf_root").join("sub").join("nested.lua"),
+        "x",
+    )
+    .unwrap();
+    fs::write(
+        temp_path
+            .join("fzf_root")
+            .join("sub")
+            .join("deep")
+            .join("verydeep.lua"),
+        "x",
+    )
+    .unwrap();
+    fs::write(
+        temp_path.join("project").join("fzf").join("plugin.lua"),
+        "x",
+    )
+    .unwrap();
+    fs::write(
+        temp_path
+            .join("project")
+            .join("fzf")
+            .join("sub")
+            .join("nested.lua"),
+        "x",
+    )
+    .unwrap();
+
+    temp_dir
+}
+
+#[test]
+fn test_matchdirs_depth1_contents_shown() {
+    let temp_dir = create_matchdirs_test_directory();
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // fzf_root matches pattern at depth 1, so its immediate children should be shown
+    assert!(output.contains("fzf_root"), "Should contain fzf_root");
+    assert!(
+        output.contains("init.lua"),
+        "Should contain init.lua (depth 2, parent matches at depth 1)"
+    );
+}
+
+#[test]
+fn test_matchdirs_depth2_contents_not_shown() {
+    let temp_dir = create_matchdirs_test_directory();
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // fzf_root/sub/nested.lua is at depth 3, parent (sub) is at depth 2 - shouldn't be shown
+    assert!(
+        !output.contains("nested.lua"),
+        "Should not contain nested.lua (depth 3)"
+    );
+    assert!(
+        !output.contains("verydeep.lua"),
+        "Should not contain verydeep.lua (depth 4)"
+    );
+}
+
+#[test]
+fn test_matchdirs_nested_match_no_contents() {
+    let temp_dir = create_matchdirs_test_directory();
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // project/fzf matches pattern but at depth 2, not depth 1
+    // So its contents should NOT be shown unfiltered
+    assert!(output.contains("fzf"), "Should contain fzf directory");
+    assert!(
+        !output.contains("plugin.lua"),
+        "Should not contain plugin.lua (fzf at depth 2, not depth 1)"
+    );
+}
+
+#[test]
+fn test_matchdirs_all_directories_shown() {
+    let temp_dir = create_matchdirs_test_directory();
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // All directories should be shown (directories never filtered by pattern)
+    assert!(output.contains("fzf_root"), "Should contain fzf_root");
+    assert!(output.contains("project"), "Should contain project");
+    assert!(output.contains("sub"), "Should contain sub directories");
+}
+
+#[test]
+fn test_matchdirs_with_prune_keeps_matched_empty() {
+    let temp_dir = tempdir().unwrap();
+    let temp_path = temp_dir.path();
+
+    // Create empty directory that matches pattern
+    fs::create_dir_all(temp_path.join("fzf_empty")).unwrap();
+    // Create non-matching directory with non-matching content
+    fs::create_dir_all(temp_path.join("other")).unwrap();
+    fs::write(temp_path.join("other").join("file.rs"), "x").unwrap();
+
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+    options.prune = true;
+
+    let result = list_directory_as_string(temp_dir.path(), &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // Matched empty directory should NOT be pruned
+    assert!(
+        output.contains("fzf_empty"),
+        "Should contain fzf_empty (matched, not pruned)"
+    );
+    // Non-matching directory with non-matching content should be pruned
+    assert!(
+        !output.contains("other"),
+        "Should not contain other (no matching content)"
+    );
+}
+
+#[test]
+fn test_matchdirs_fromfile_depth1_contents_shown() {
+    let temp_dir = tempdir().unwrap();
+    let listing_file = temp_dir.path().join("listing.txt");
+
+    // Create file listing similar to filesystem test structure
+    let content = "fzf_root/\nfzf_root/init.lua\nfzf_root/sub/\nfzf_root/sub/nested.lua\nproject/\nproject/fzf/\nproject/fzf/plugin.lua\n";
+    fs::write(&listing_file, content).unwrap();
+
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+    options.from_file = true;
+
+    let result = list_directory_as_string(&listing_file, &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // fzf_root matches at depth 1, so init.lua should be shown
+    assert!(output.contains("fzf_root"), "Should contain fzf_root");
+    assert!(
+        output.contains("init.lua"),
+        "Should contain init.lua (parent matches at depth 1)"
+    );
+}
+
+#[test]
+fn test_matchdirs_fromfile_nested_not_shown() {
+    let temp_dir = tempdir().unwrap();
+    let listing_file = temp_dir.path().join("listing.txt");
+
+    let content = "fzf_root/\nfzf_root/init.lua\nfzf_root/sub/\nfzf_root/sub/nested.lua\nproject/\nproject/fzf/\nproject/fzf/plugin.lua\n";
+    fs::write(&listing_file, content).unwrap();
+
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+    options.from_file = true;
+
+    let result = list_directory_as_string(&listing_file, &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // nested.lua parent is "sub" at depth 2, should not be shown
+    assert!(
+        !output.contains("nested.lua"),
+        "Should not contain nested.lua (parent at depth 2)"
+    );
+    // plugin.lua parent is "fzf" at depth 2, should not be shown
+    assert!(
+        !output.contains("plugin.lua"),
+        "Should not contain plugin.lua (fzf at depth 2)"
+    );
+}
+
+#[test]
+fn test_matchdirs_fromfile_prune_keeps_matched() {
+    let temp_dir = tempdir().unwrap();
+    let listing_file = temp_dir.path().join("listing.txt");
+
+    // fzf_empty is empty but matches pattern
+    let content = "fzf_empty/\nother/\nother/file.rs\n";
+    fs::write(&listing_file, content).unwrap();
+
+    let mut options = create_default_options();
+    options.pattern_glob = Some(Pattern::new("fzf*").unwrap());
+    options.match_dirs = true;
+    options.prune = true;
+    options.from_file = true;
+
+    let result = list_directory_as_string(&listing_file, &options);
+    assert!(result.is_ok());
+
+    let output = result.unwrap();
+
+    // Matched empty directory should NOT be pruned
+    assert!(
+        output.contains("fzf_empty"),
+        "Should contain fzf_empty (matched, not pruned)"
+    );
+    // Non-matching directory with non-matching content should be pruned
+    assert!(
+        !output.contains("other"),
+        "Should not contain other (no matching content)"
+    );
 }

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -34,6 +34,7 @@ fn create_basic_options() -> TreeOptions {
         from_file: false,
         icons: false,
         prune: false,
+        match_dirs: false,
     }
 }
 


### PR DESCRIPTION
The `--matchdirs` flag in Linux's tree supports a --matchdirs flag which applies `-P` pattern to directory names instead of just files. Pattern filtering is disabled for matching directories.

The new flag is useful for searching for directories by name, and may be of use in other use cases making use of the directory listing functionality, like #37 ( I'm not sure it actually resolves that issue though).

This adds the same `--matchdirs` behavior as the Linux tree.