### PR TITLE
feat: Add `--gitignore` for excluding gitignored files

### DIFF
--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -174,6 +174,9 @@ pub struct Cli {
         help = "Include directory names in -P pattern matching. Matched directories show all contents."
     )]
     pub match_dirs: bool,
+
+    #[arg(long = "gitignore", help = "Exclude entries matching .gitignore rules.")]
+    pub gitignore: bool,
 }
 
 /// Convert CLI arguments to TreeOptions
@@ -221,6 +224,7 @@ pub fn cli_to_options(cli: &Cli) -> Result<TreeOptions, String> {
         from_file: cli.fromfile,
         icons: cli.icons,
         prune: cli.prune,
+        gitignore: cli.gitignore,
     })
 }
 
@@ -295,6 +299,7 @@ mod tests {
             icons: false,
             prune: false,
             match_dirs: false,
+            gitignore: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -334,6 +339,7 @@ mod tests {
             icons: false,
             prune: false,
             match_dirs: false,
+            gitignore: false,
         };
 
         let options = cli_to_options(&cli).unwrap();
@@ -423,6 +429,7 @@ mod tests {
             icons: false,
             prune: false,
             match_dirs: false,
+            gitignore: false,
         };
 
         let result = cli_to_options(&cli);

--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -395,6 +395,7 @@ mod tests {
             icons: false,
             prune: false,
             match_dirs: false,
+            gitignore: false,
         };
 
         let options = cli_to_options(&cli).unwrap();

--- a/src/rust_tree/cli.rs
+++ b/src/rust_tree/cli.rs
@@ -175,7 +175,10 @@ pub struct Cli {
     )]
     pub match_dirs: bool,
 
-    #[arg(long = "gitignore", help = "Exclude entries matching .gitignore rules.")]
+    #[arg(
+        long = "gitignore",
+        help = "Exclude entries matching .gitignore rules."
+    )]
     pub gitignore: bool,
 }
 

--- a/src/rust_tree/gitignore.rs
+++ b/src/rust_tree/gitignore.rs
@@ -3,7 +3,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const MATCH_OPTIONS: MatchOptions = MatchOptions {
-    case_sensitive: true,
+    case_sensitive: !cfg!(any(target_os = "macos", target_os = "windows")),
     require_literal_separator: true,
     require_literal_leading_dot: false,
 };
@@ -27,22 +27,22 @@ fn parse_line(line: &str, source_dir: &Path) -> Option<GitignoreRule> {
         return None;
     }
 
-    let mut s = trimmed.to_string();
+    let (negated, s) = match trimmed.strip_prefix('!') {
+        Some(rest) => (true, rest),
+        None => (false, trimmed),
+    };
 
-    let negated = s.starts_with('!');
-    if negated {
-        s = s[1..].to_string();
-    }
+    let (dir_only, s) = match s.strip_suffix('/') {
+        Some(rest) => (true, rest),
+        None => (false, s),
+    };
 
-    let dir_only = s.ends_with('/');
-    if dir_only {
-        s = s[..s.len() - 1].to_string();
-    }
+    let (has_leading_slash, s) = match s.strip_prefix('/') {
+        Some(rest) => (true, rest),
+        None => (false, s),
+    };
 
-    let has_leading_slash = s.starts_with('/');
-    if has_leading_slash {
-        s = s[1..].to_string();
-    }
+    let mut s = s.to_string();
 
     let anchored = has_leading_slash || s.contains('/');
 
@@ -92,14 +92,19 @@ impl GitignoreRules {
         Self { rules }
     }
 
-    pub fn extend_with_dir(&self, dir_path: &Path, root_path: &Path) -> Self {
-        let mut rules = self.rules.clone();
+    pub fn extend_with_dir(&self, dir_path: &Path, root_path: &Path) -> Option<Self> {
         let rel_source = dir_path.strip_prefix(root_path).unwrap_or(dir_path);
+        let mut new_rules = Vec::new();
         for name in &[".gitignore", ".ignore"] {
             let file_path = dir_path.join(name);
-            rules.extend(load_ignore_file(&file_path, rel_source));
+            new_rules.extend(load_ignore_file(&file_path, rel_source));
         }
-        Self { rules }
+        if new_rules.is_empty() {
+            return None;
+        }
+        let mut rules = self.rules.clone();
+        rules.append(&mut new_rules);
+        Some(Self { rules })
     }
 
     pub fn is_ignored(&self, rel_path: &Path, is_dir: bool) -> bool {
@@ -311,10 +316,29 @@ mod tests {
         let root_rules = GitignoreRules::load_for_root(dir.path());
         assert_eq!(root_rules.rules.len(), 1);
 
-        let extended = root_rules.extend_with_dir(&child, dir.path());
+        let extended = root_rules.extend_with_dir(&child, dir.path()).unwrap();
         assert_eq!(extended.rules.len(), 2);
         assert!(extended.is_ignored(Path::new("foo.log"), false));
         assert!(extended.is_ignored(Path::new("bar.tmp"), false));
+    }
+
+    #[test]
+    fn extend_with_dir_returns_none_when_no_ignore_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("sub");
+        fs::create_dir(&child).unwrap();
+
+        let root_rules = GitignoreRules::load_for_root(dir.path());
+        assert!(root_rules.extend_with_dir(&child, dir.path()).is_none());
+    }
+
+    #[test]
+    fn case_sensitivity_matches_platform() {
+        if cfg!(any(target_os = "macos", target_os = "windows")) {
+            assert!(!MATCH_OPTIONS.case_sensitive);
+        } else {
+            assert!(MATCH_OPTIONS.case_sensitive);
+        }
     }
 
     #[test]

--- a/src/rust_tree/gitignore.rs
+++ b/src/rust_tree/gitignore.rs
@@ -1,0 +1,333 @@
+use glob::{MatchOptions, Pattern};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const MATCH_OPTIONS: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
+
+struct GitignoreRule {
+    pattern: Pattern,
+    negated: bool,
+    dir_only: bool,
+    anchored: bool,
+    source_dir: PathBuf,
+}
+
+pub struct GitignoreRules {
+    rules: Vec<GitignoreRule>,
+}
+
+fn parse_line(line: &str, source_dir: &Path) -> Option<GitignoreRule> {
+    let trimmed = line.trim_end();
+    if trimmed.is_empty() || trimmed.starts_with('#') {
+        return None;
+    }
+
+    let mut s = trimmed.to_string();
+
+    let negated = s.starts_with('!');
+    if negated {
+        s = s[1..].to_string();
+    }
+
+    let dir_only = s.ends_with('/');
+    if dir_only {
+        s = s[..s.len() - 1].to_string();
+    }
+
+    let has_leading_slash = s.starts_with('/');
+    if has_leading_slash {
+        s = s[1..].to_string();
+    }
+
+    let anchored = has_leading_slash || s.contains('/');
+
+    if !anchored {
+        s = format!("**/{s}");
+    }
+
+    let pattern = Pattern::new(&s).ok()?;
+
+    Some(GitignoreRule {
+        pattern,
+        negated,
+        dir_only,
+        anchored,
+        source_dir: source_dir.to_path_buf(),
+    })
+}
+
+fn load_ignore_file(path: &Path, source_dir: &Path) -> Vec<GitignoreRule> {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+    content
+        .lines()
+        .filter_map(|line| parse_line(line, source_dir))
+        .collect()
+}
+
+impl Default for GitignoreRules {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GitignoreRules {
+    pub fn new() -> Self {
+        Self { rules: Vec::new() }
+    }
+
+    pub fn load_for_root(root_path: &Path) -> Self {
+        let mut rules = Vec::new();
+        for name in &[".gitignore", ".ignore"] {
+            let file_path = root_path.join(name);
+            rules.extend(load_ignore_file(&file_path, root_path));
+        }
+        Self { rules }
+    }
+
+    pub fn extend_with_dir(&self, dir_path: &Path) -> Self {
+        let mut rules = self.rules.iter().map(|r| GitignoreRule {
+            pattern: r.pattern.clone(),
+            negated: r.negated,
+            dir_only: r.dir_only,
+            anchored: r.anchored,
+            source_dir: r.source_dir.clone(),
+        }).collect::<Vec<_>>();
+        for name in &[".gitignore", ".ignore"] {
+            let file_path = dir_path.join(name);
+            rules.extend(load_ignore_file(&file_path, dir_path));
+        }
+        Self { rules }
+    }
+
+    pub fn is_ignored(&self, rel_path: &Path, is_dir: bool) -> bool {
+        let mut ignored = false;
+        for rule in &self.rules {
+            if rule.dir_only && !is_dir {
+                continue;
+            }
+            let match_path = if rule.anchored {
+                match rel_path.strip_prefix(&rule.source_dir) {
+                    Ok(p) => p,
+                    Err(_) => rel_path,
+                }
+            } else {
+                rel_path
+            };
+            if rule.pattern.matches_path_with(match_path, MATCH_OPTIONS) {
+                ignored = !rule.negated;
+            }
+        }
+        ignored
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rules.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_star_star_matches_zero_segments() {
+        assert!(Pattern::new("**/*.log")
+            .unwrap()
+            .matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
+        assert!(Pattern::new("**/build")
+            .unwrap()
+            .matches_path_with(Path::new("build"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn glob_star_star_matches_multiple_segments() {
+        assert!(Pattern::new("**/*.log")
+            .unwrap()
+            .matches_path_with(Path::new("a/b/foo.log"), MATCH_OPTIONS));
+        assert!(Pattern::new("**/build")
+            .unwrap()
+            .matches_path_with(Path::new("src/build"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn parse_simple_pattern() {
+        let rule = parse_line("*.log", Path::new("")).unwrap();
+        assert!(!rule.negated);
+        assert!(!rule.dir_only);
+        assert!(!rule.anchored);
+        assert!(rule.pattern.matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
+        assert!(rule.pattern.matches_path_with(Path::new("a/b/foo.log"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn parse_dir_only_pattern() {
+        let rule = parse_line("build/", Path::new("")).unwrap();
+        assert!(!rule.negated);
+        assert!(rule.dir_only);
+        assert!(!rule.anchored);
+        assert!(rule.pattern.matches_path_with(Path::new("build"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn parse_anchored_leading_slash() {
+        let rule = parse_line("/build", Path::new("")).unwrap();
+        assert!(!rule.negated);
+        assert!(!rule.dir_only);
+        assert!(rule.anchored);
+        assert!(rule.pattern.matches_path_with(Path::new("build"), MATCH_OPTIONS));
+        assert!(!rule.pattern.matches_path_with(Path::new("src/build"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn parse_anchored_contains_slash() {
+        let rule = parse_line("src/generated", Path::new("")).unwrap();
+        assert!(rule.anchored);
+        assert!(rule.pattern.matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
+        assert!(!rule.pattern.matches_path_with(Path::new("other/src/generated"), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn parse_negated_pattern() {
+        let rule = parse_line("!*.log", Path::new("")).unwrap();
+        assert!(rule.negated);
+        assert!(!rule.dir_only);
+        assert!(!rule.anchored);
+    }
+
+    #[test]
+    fn parse_negated_dir_only() {
+        let rule = parse_line("!build/", Path::new("")).unwrap();
+        assert!(rule.negated);
+        assert!(rule.dir_only);
+    }
+
+    #[test]
+    fn parse_comment_and_blank_lines() {
+        assert!(parse_line("# comment", Path::new("")).is_none());
+        assert!(parse_line("", Path::new("")).is_none());
+        assert!(parse_line("   ", Path::new("")).is_none());
+    }
+
+    #[test]
+    fn parse_trailing_whitespace_stripped() {
+        let rule = parse_line("*.log   ", Path::new("")).unwrap();
+        assert!(rule.pattern.matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
+        assert!(!rule.pattern.matches_path_with(Path::new("foo.log   "), MATCH_OPTIONS));
+    }
+
+    #[test]
+    fn is_ignored_last_match_wins() {
+        let rules = GitignoreRules {
+            rules: vec![
+                parse_line("*.log", Path::new("")).unwrap(),
+                parse_line("!important.log", Path::new("")).unwrap(),
+            ],
+        };
+        assert!(rules.is_ignored(Path::new("debug.log"), false));
+        assert!(!rules.is_ignored(Path::new("important.log"), false));
+    }
+
+    #[test]
+    fn is_ignored_dir_only_skips_files() {
+        let rules = GitignoreRules {
+            rules: vec![parse_line("build/", Path::new("")).unwrap()],
+        };
+        assert!(rules.is_ignored(Path::new("build"), true));
+        assert!(!rules.is_ignored(Path::new("build"), false));
+    }
+
+    #[test]
+    fn is_ignored_anchored_relative_to_source_dir() {
+        let rules = GitignoreRules {
+            rules: vec![parse_line("src/generated", Path::new("project")).unwrap()],
+        };
+        assert!(rules.is_ignored(Path::new("project/src/generated"), false));
+        assert!(!rules.is_ignored(Path::new("other/src/generated"), false));
+    }
+
+    #[test]
+    fn is_empty_with_no_rules() {
+        let rules = GitignoreRules::new();
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn is_empty_with_rules() {
+        let rules = GitignoreRules {
+            rules: vec![parse_line("*.log", Path::new("")).unwrap()],
+        };
+        assert!(!rules.is_empty());
+    }
+
+    #[test]
+    fn load_for_root_with_temp_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".gitignore"), "*.log\nbuild/\n").unwrap();
+        let rules = GitignoreRules::load_for_root(dir.path());
+        assert_eq!(rules.rules.len(), 2);
+        assert!(rules.is_ignored(Path::new("foo.log"), false));
+        assert!(rules.is_ignored(Path::new("build"), true));
+        assert!(!rules.is_ignored(Path::new("build"), false));
+    }
+
+    #[test]
+    fn load_for_root_reads_ignore_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(".ignore"), "secret/\n").unwrap();
+        let rules = GitignoreRules::load_for_root(dir.path());
+        assert_eq!(rules.rules.len(), 1);
+        assert!(rules.is_ignored(Path::new("secret"), true));
+    }
+
+    #[test]
+    fn extend_with_dir_adds_child_rules() {
+        let dir = tempfile::tempdir().unwrap();
+        let child = dir.path().join("sub");
+        fs::create_dir(&child).unwrap();
+        fs::write(dir.path().join(".gitignore"), "*.log\n").unwrap();
+        fs::write(child.join(".gitignore"), "*.tmp\n").unwrap();
+
+        let root_rules = GitignoreRules::load_for_root(dir.path());
+        assert_eq!(root_rules.rules.len(), 1);
+
+        let extended = root_rules.extend_with_dir(&child);
+        assert_eq!(extended.rules.len(), 2);
+        assert!(extended.is_ignored(Path::new("foo.log"), false));
+        assert!(extended.is_ignored(Path::new("bar.tmp"), false));
+    }
+
+    #[test]
+    fn load_for_root_no_files_returns_empty() {
+        let dir = tempfile::tempdir().unwrap();
+        let rules = GitignoreRules::load_for_root(dir.path());
+        assert!(rules.is_empty());
+    }
+
+    #[test]
+    fn complex_negation_scenario() {
+        let rules = GitignoreRules {
+            rules: vec![
+                parse_line("*.log", Path::new("")).unwrap(),
+                parse_line("!important.log", Path::new("")).unwrap(),
+                parse_line("important.log", Path::new("")).unwrap(),
+            ],
+        };
+        assert!(rules.is_ignored(Path::new("important.log"), false));
+        assert!(rules.is_ignored(Path::new("debug.log"), false));
+    }
+
+    #[test]
+    fn anchored_dir_only_combined() {
+        let rule = parse_line("src/generated/", Path::new("")).unwrap();
+        assert!(rule.anchored);
+        assert!(rule.dir_only);
+        assert!(rule.pattern.matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
+    }
+}

--- a/src/rust_tree/gitignore.rs
+++ b/src/rust_tree/gitignore.rs
@@ -116,7 +116,7 @@ impl GitignoreRules {
             let match_path = if rule.anchored {
                 match rel_path.strip_prefix(&rule.source_dir) {
                     Ok(p) => p,
-                    Err(_) => rel_path,
+                    Err(_) => continue,
                 }
             } else {
                 rel_path

--- a/src/rust_tree/gitignore.rs
+++ b/src/rust_tree/gitignore.rs
@@ -8,6 +8,7 @@ const MATCH_OPTIONS: MatchOptions = MatchOptions {
     require_literal_leading_dot: false,
 };
 
+#[derive(Clone)]
 struct GitignoreRule {
     pattern: Pattern,
     negated: bool,
@@ -92,13 +93,7 @@ impl GitignoreRules {
     }
 
     pub fn extend_with_dir(&self, dir_path: &Path) -> Self {
-        let mut rules = self.rules.iter().map(|r| GitignoreRule {
-            pattern: r.pattern.clone(),
-            negated: r.negated,
-            dir_only: r.dir_only,
-            anchored: r.anchored,
-            source_dir: r.source_dir.clone(),
-        }).collect::<Vec<_>>();
+        let mut rules = self.rules.clone();
         for name in &[".gitignore", ".ignore"] {
             let file_path = dir_path.join(name);
             rules.extend(load_ignore_file(&file_path, dir_path));
@@ -162,8 +157,12 @@ mod tests {
         assert!(!rule.negated);
         assert!(!rule.dir_only);
         assert!(!rule.anchored);
-        assert!(rule.pattern.matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
-        assert!(rule.pattern.matches_path_with(Path::new("a/b/foo.log"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("a/b/foo.log"), MATCH_OPTIONS));
     }
 
     #[test]
@@ -172,7 +171,9 @@ mod tests {
         assert!(!rule.negated);
         assert!(rule.dir_only);
         assert!(!rule.anchored);
-        assert!(rule.pattern.matches_path_with(Path::new("build"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("build"), MATCH_OPTIONS));
     }
 
     #[test]
@@ -181,16 +182,24 @@ mod tests {
         assert!(!rule.negated);
         assert!(!rule.dir_only);
         assert!(rule.anchored);
-        assert!(rule.pattern.matches_path_with(Path::new("build"), MATCH_OPTIONS));
-        assert!(!rule.pattern.matches_path_with(Path::new("src/build"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("build"), MATCH_OPTIONS));
+        assert!(!rule
+            .pattern
+            .matches_path_with(Path::new("src/build"), MATCH_OPTIONS));
     }
 
     #[test]
     fn parse_anchored_contains_slash() {
         let rule = parse_line("src/generated", Path::new("")).unwrap();
         assert!(rule.anchored);
-        assert!(rule.pattern.matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
-        assert!(!rule.pattern.matches_path_with(Path::new("other/src/generated"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
+        assert!(!rule
+            .pattern
+            .matches_path_with(Path::new("other/src/generated"), MATCH_OPTIONS));
     }
 
     #[test]
@@ -218,8 +227,12 @@ mod tests {
     #[test]
     fn parse_trailing_whitespace_stripped() {
         let rule = parse_line("*.log   ", Path::new("")).unwrap();
-        assert!(rule.pattern.matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
-        assert!(!rule.pattern.matches_path_with(Path::new("foo.log   "), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("foo.log"), MATCH_OPTIONS));
+        assert!(!rule
+            .pattern
+            .matches_path_with(Path::new("foo.log   "), MATCH_OPTIONS));
     }
 
     #[test]
@@ -328,6 +341,8 @@ mod tests {
         let rule = parse_line("src/generated/", Path::new("")).unwrap();
         assert!(rule.anchored);
         assert!(rule.dir_only);
-        assert!(rule.pattern.matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
+        assert!(rule
+            .pattern
+            .matches_path_with(Path::new("src/generated"), MATCH_OPTIONS));
     }
 }

--- a/src/rust_tree/gitignore.rs
+++ b/src/rust_tree/gitignore.rs
@@ -87,16 +87,17 @@ impl GitignoreRules {
         let mut rules = Vec::new();
         for name in &[".gitignore", ".ignore"] {
             let file_path = root_path.join(name);
-            rules.extend(load_ignore_file(&file_path, root_path));
+            rules.extend(load_ignore_file(&file_path, Path::new("")));
         }
         Self { rules }
     }
 
-    pub fn extend_with_dir(&self, dir_path: &Path) -> Self {
+    pub fn extend_with_dir(&self, dir_path: &Path, root_path: &Path) -> Self {
         let mut rules = self.rules.clone();
+        let rel_source = dir_path.strip_prefix(root_path).unwrap_or(dir_path);
         for name in &[".gitignore", ".ignore"] {
             let file_path = dir_path.join(name);
-            rules.extend(load_ignore_file(&file_path, dir_path));
+            rules.extend(load_ignore_file(&file_path, rel_source));
         }
         Self { rules }
     }
@@ -310,7 +311,7 @@ mod tests {
         let root_rules = GitignoreRules::load_for_root(dir.path());
         assert_eq!(root_rules.rules.len(), 1);
 
-        let extended = root_rules.extend_with_dir(&child);
+        let extended = root_rules.extend_with_dir(&child, dir.path());
         assert_eq!(extended.rules.len(), 2);
         assert!(extended.is_ignored(Path::new("foo.log"), false));
         assert!(extended.is_ignored(Path::new("bar.tmp"), false));

--- a/src/rust_tree/mod.rs
+++ b/src/rust_tree/mod.rs
@@ -1,6 +1,7 @@
 pub mod cli;
 pub mod display;
 pub mod fromfile;
+pub mod gitignore;
 pub mod icons;
 pub mod options;
 pub mod traversal;

--- a/src/rust_tree/options.rs
+++ b/src/rust_tree/options.rs
@@ -26,4 +26,5 @@ pub struct TreeOptions {
     pub from_file: bool,
     pub icons: bool,
     pub prune: bool,
+    pub gitignore: bool,
 }

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -17,6 +17,7 @@ use crate::rust_tree::display::format_permissions_unix;
 use crate::rust_tree::fromfile::{
     build_virtual_tree, parse_file_listing, read_file_listing, FileEntry, VirtualTree,
 };
+use crate::rust_tree::gitignore::GitignoreRules;
 use crate::rust_tree::options::TreeOptions;
 use crate::rust_tree::utils::bytes_to_human_readable;
 
@@ -88,6 +89,8 @@ fn should_skip_entry(
     entry: &fs::DirEntry,
     options: &TreeOptions,
     parent_matched: bool,
+    gitignore_rules: &GitignoreRules,
+    root_path: &Path,
 ) -> std::io::Result<bool> {
     let path = entry.path();
     let file_name = path.file_name().and_then(|name| name.to_str());
@@ -95,6 +98,14 @@ fn should_skip_entry(
     let is_hidden = file_name.map(|name| name.starts_with('.')).unwrap_or(false);
     if !options.all_files && is_hidden {
         return Ok(true);
+    }
+
+    if !gitignore_rules.is_empty() {
+        let rel_path = path.strip_prefix(root_path).unwrap_or(&path);
+        let is_dir = path.is_dir();
+        if gitignore_rules.is_ignored(rel_path, is_dir) {
+            return Ok(true);
+        }
     }
 
     for exclude_pattern in &options.exclude_patterns {
@@ -300,6 +311,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
     indent_state: &[bool],
     icon_manager: &IconManager,
     parent_matched: bool,
+    gitignore_rules: &GitignoreRules,
 ) -> std::io::Result<bool> {
     // --- 1. Read and Pre-process Directory Entries ---
     let read_dir_result = fs::read_dir(current_path);
@@ -307,7 +319,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
         Ok(reader) => reader
             .filter_map(Result::ok)
             .filter(
-                |entry| match should_skip_entry(entry, options, parent_matched) {
+                |entry| match should_skip_entry(entry, options, parent_matched, gitignore_rules, root_path.as_ref()) {
                     Ok(skip) => !skip,
                     Err(e) => {
                         eprintln!(
@@ -410,6 +422,16 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                     let has_content = if skip {
                         false
                     } else {
+                        let probe_rules = if options.gitignore {
+                            gitignore_rules.extend_with_dir(&path)
+                        } else {
+                            GitignoreRules::new()
+                        };
+                        let probe_rules_ref = if options.gitignore {
+                            &probe_rules
+                        } else {
+                            gitignore_rules
+                        };
                         let mut probe_stats = (0u64, 0u64);
                         traverse_directory(
                             &mut io::sink(),
@@ -421,6 +443,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                             &[],
                             icon_manager,
                             child_matched,
+                            probe_rules_ref,
                         )?
                     };
                     Ok(has_content || child_matched)
@@ -455,6 +478,16 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
             found_content = true;
 
             if !skip_recursion {
+                let child_rules = if options.gitignore {
+                    gitignore_rules.extend_with_dir(&path)
+                } else {
+                    GitignoreRules::new()
+                };
+                let child_rules_ref = if options.gitignore {
+                    &child_rules
+                } else {
+                    gitignore_rules
+                };
                 let mut next_indent_state = indent_state.to_vec();
                 next_indent_state.push(is_last);
                 traverse_directory(
@@ -467,6 +500,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                     &next_indent_state,
                     icon_manager,
                     child_parent_matched,
+                    child_rules_ref,
                 )?;
             }
         } else {
@@ -605,6 +639,12 @@ fn list_from_filesystem_with_writer<W: Write>(
     // Create icon manager if icons are enabled
     let icon_manager = IconManager::new();
 
+    let gitignore_rules = if options.gitignore {
+        GitignoreRules::load_for_root(current_path)
+    } else {
+        GitignoreRules::new()
+    };
+
     traverse_directory(
         &mut writer,
         current_path,
@@ -615,6 +655,7 @@ fn list_from_filesystem_with_writer<W: Write>(
         &[],
         &icon_manager,
         false,
+        &gitignore_rules,
     )?;
 
     if !options.no_report {

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -529,6 +529,7 @@ pub fn list_directory<P: AsRef<Path>>(path: P, options: &TreeOptions) -> std::io
 ///     from_file: false,
 ///     icons: false,
 ///     prune: false,
+///     gitignore: false,
 /// };
 /// let tree_output = list_directory_as_string(".", &options).unwrap();
 /// println!("{}", tree_output);

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -428,13 +428,15 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                     let has_content = if skip {
                         false
                     } else {
-                        let probe_rules = if options.gitignore {
-                            gitignore_rules.extend_with_dir(&path, root_path.as_ref())
-                        } else {
-                            GitignoreRules::new()
-                        };
+                        let probe_rules;
                         let probe_rules_ref = if options.gitignore {
-                            &probe_rules
+                            match gitignore_rules.extend_with_dir(&path, root_path.as_ref()) {
+                                Some(rules) => {
+                                    probe_rules = rules;
+                                    &probe_rules
+                                }
+                                None => gitignore_rules,
+                            }
                         } else {
                             gitignore_rules
                         };
@@ -484,13 +486,15 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
             found_content = true;
 
             if !skip_recursion {
-                let child_rules = if options.gitignore {
-                    gitignore_rules.extend_with_dir(&path, root_path.as_ref())
-                } else {
-                    GitignoreRules::new()
-                };
+                let child_rules;
                 let child_rules_ref = if options.gitignore {
-                    &child_rules
+                    match gitignore_rules.extend_with_dir(&path, root_path.as_ref()) {
+                        Some(rules) => {
+                            child_rules = rules;
+                            &child_rules
+                        }
+                        None => gitignore_rules,
+                    }
                 } else {
                     gitignore_rules
                 };

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -318,8 +318,14 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
     let mut entries_info: Vec<EntryInfo> = match read_dir_result {
         Ok(reader) => reader
             .filter_map(Result::ok)
-            .filter(
-                |entry| match should_skip_entry(entry, options, parent_matched, gitignore_rules, root_path.as_ref()) {
+            .filter(|entry| {
+                match should_skip_entry(
+                    entry,
+                    options,
+                    parent_matched,
+                    gitignore_rules,
+                    root_path.as_ref(),
+                ) {
                     Ok(skip) => !skip,
                     Err(e) => {
                         eprintln!(
@@ -329,8 +335,8 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                         );
                         false
                     }
-                },
-            )
+                }
+            })
             .map(|entry| {
                 // Get metadata/mod_time needed for sorting
                 let mod_time = entry.metadata().and_then(|m| m.modified());

--- a/src/rust_tree/traversal.rs
+++ b/src/rust_tree/traversal.rs
@@ -102,7 +102,7 @@ fn should_skip_entry(
 
     if !gitignore_rules.is_empty() {
         let rel_path = path.strip_prefix(root_path).unwrap_or(&path);
-        let is_dir = path.is_dir();
+        let is_dir = entry.file_type()?.is_dir();
         if gitignore_rules.is_ignored(rel_path, is_dir) {
             return Ok(true);
         }
@@ -429,7 +429,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
                         false
                     } else {
                         let probe_rules = if options.gitignore {
-                            gitignore_rules.extend_with_dir(&path)
+                            gitignore_rules.extend_with_dir(&path, root_path.as_ref())
                         } else {
                             GitignoreRules::new()
                         };
@@ -485,7 +485,7 @@ pub fn traverse_directory<P: AsRef<Path>, W: Write>(
 
             if !skip_recursion {
                 let child_rules = if options.gitignore {
-                    gitignore_rules.extend_with_dir(&path)
+                    gitignore_rules.extend_with_dir(&path, root_path.as_ref())
                 } else {
                     GitignoreRules::new()
                 };

--- a/tests/cli_unit_tests.rs
+++ b/tests/cli_unit_tests.rs
@@ -32,6 +32,7 @@ fn create_test_options() -> TreeOptions {
         icons: false,
         prune: false,
         match_dirs: false,
+        gitignore: false,
     }
 }
 
@@ -92,6 +93,7 @@ fn test_tree_options_defaults() {
         icons: false,
         prune: false,
         match_dirs: false,
+        gitignore: false,
     };
 
     // Test default values

--- a/tests/gitignore_tests.rs
+++ b/tests/gitignore_tests.rs
@@ -534,6 +534,43 @@ fn exclude_plus_gitignore_compose() {
 }
 
 #[test]
+fn nested_gitignore_anchored_pattern_matches_in_subtree() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    // Root has no .gitignore
+    fs::create_dir(p.join("sub")).unwrap();
+    // Nested .gitignore with anchored pattern "/config"
+    fs::write(p.join("sub").join(".gitignore"), "/config\n").unwrap();
+
+    // sub/config should be ignored (anchored to sub/)
+    fs::create_dir(p.join("sub").join("config")).unwrap();
+    fs::write(p.join("sub").join("config").join("settings.json"), "").unwrap();
+    fs::write(p.join("sub").join("code.rs"), "").unwrap();
+
+    // root-level config should NOT be ignored (rule is in sub/.gitignore)
+    fs::create_dir(p.join("config")).unwrap();
+    fs::write(p.join("config").join("global.json"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        output.contains("code.rs"),
+        "Non-ignored file in sub/ should appear"
+    );
+    assert!(
+        output.contains("global.json"),
+        "Root-level config/global.json should appear (rule is scoped to sub/)"
+    );
+    assert!(
+        !output.contains("settings.json"),
+        "sub/config/settings.json should be hidden by nested anchored /config pattern"
+    );
+}
+
+#[test]
 fn fromfile_plus_gitignore_silently_ignored() {
     let dir = tempdir().unwrap();
     let listing_file = dir.path().join("listing.txt");

--- a/tests/gitignore_tests.rs
+++ b/tests/gitignore_tests.rs
@@ -41,8 +41,6 @@ fn gitignore_options() -> TreeOptions {
     opts
 }
 
-// ── Basic Filtering ──────────────────────────────────────────────
-
 #[test]
 fn root_gitignore_hides_matched_files_at_root() {
     let dir = tempdir().unwrap();
@@ -78,7 +76,10 @@ fn root_gitignore_hides_matched_files_in_subdirectories() {
         !output.contains("nested.log"),
         "Gitignored file in subdirectory should be hidden"
     );
-    assert!(output.contains("keep.txt"), "Non-ignored file should appear");
+    assert!(
+        output.contains("keep.txt"),
+        "Non-ignored file should appear"
+    );
 }
 
 #[test]
@@ -186,8 +187,6 @@ fn no_op_when_no_gitignore_file_exists() {
     );
 }
 
-// ── Pattern Types ────────────────────────────────────────────────
-
 #[test]
 fn unanchored_glob_matches_at_any_depth() {
     let dir = tempdir().unwrap();
@@ -218,7 +217,10 @@ fn anchored_pattern_with_slash() {
     fs::write(p.join("src").join("generated").join("root_out.rs"), "").unwrap();
     fs::create_dir_all(p.join("other").join("src").join("generated")).unwrap();
     fs::write(
-        p.join("other").join("src").join("generated").join("other_out.rs"),
+        p.join("other")
+            .join("src")
+            .join("generated")
+            .join("other_out.rs"),
         "",
     )
     .unwrap();
@@ -227,12 +229,10 @@ fn anchored_pattern_with_slash() {
     opts.all_files = true;
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // Anchored pattern "src/generated" matches at root only
     assert!(
         !output.contains("root_out.rs"),
         "src/generated/root_out.rs should be hidden by anchored pattern"
     );
-    // other/src/generated should NOT be matched by anchored pattern
     assert!(
         output.contains("other_out.rs"),
         "other/src/generated/other_out.rs should remain (not anchored at root)"
@@ -254,19 +254,13 @@ fn leading_slash_anchor_matches_only_at_root() {
     opts.all_files = true;
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // Root /build should be hidden
-    // But src/build should remain
     assert!(
         output.contains("nested.o"),
         "src/build/nested.o should remain (not anchored at root)"
     );
-    // Root build dir should be gone
     let lines: Vec<&str> = output.lines().collect();
     let has_root_build_content = lines.iter().any(|l| l.contains("out.o"));
-    assert!(
-        !has_root_build_content,
-        "Root build/out.o should be hidden"
-    );
+    assert!(!has_root_build_content, "Root build/out.o should be hidden");
 }
 
 #[test]
@@ -277,19 +271,16 @@ fn dir_only_pattern_matches_directories_not_files() {
     fs::write(p.join(".gitignore"), "build/\n").unwrap();
     fs::create_dir(p.join("build")).unwrap();
     fs::write(p.join("build").join("out.o"), "").unwrap();
-    // Create a file named "build" (not a directory)
     fs::write(p.join("sub_build"), "").unwrap();
 
     let mut opts = gitignore_options();
     opts.all_files = true;
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // The build/ directory should be hidden
     assert!(
         !output.contains("out.o"),
         "Contents of build/ dir should be hidden"
     );
-    // A file named sub_build should remain (dir-only pattern)
     assert!(
         output.contains("sub_build"),
         "File named sub_build should not be hidden by dir-only pattern"
@@ -343,8 +334,6 @@ fn parent_dir_exclusion_blocks_child_negation() {
     let dir = tempdir().unwrap();
     let p = dir.path();
 
-    // Ignore the build directory, then try to un-ignore a file inside it
-    // Git behavior: if parent dir is excluded, child negation cannot bring it back
     fs::write(p.join(".gitignore"), "build/\n!build/output.txt\n").unwrap();
     fs::create_dir(p.join("build")).unwrap();
     fs::write(p.join("build").join("output.txt"), "").unwrap();
@@ -354,15 +343,12 @@ fn parent_dir_exclusion_blocks_child_negation() {
     opts.all_files = true;
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // The build directory itself is excluded, so nothing inside can be un-ignored
     assert!(
         !output.contains("output.txt"),
         "Cannot un-ignore file inside excluded parent directory"
     );
     assert!(!output.contains("other.o"));
 }
-
-// ── Flag Combinations ────────────────────────────────────────────
 
 #[test]
 fn prune_plus_gitignore() {
@@ -408,8 +394,6 @@ fn pattern_plus_gitignore() {
     opts.pattern_glob = Some(Pattern::new("*.log").unwrap());
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // *.log matches the pattern filter, but gitignore also hides *.log
-    // gitignore should take precedence
     assert!(
         !output.contains("app.log"),
         "Gitignored files excluded despite matching -P pattern"
@@ -446,14 +430,11 @@ fn filelimit_plus_gitignore_uses_raw_count() {
     let p = dir.path();
 
     fs::write(p.join(".gitignore"), "*.log\n").unwrap();
-    // Create a directory with 3 total entries (2 .log + 1 .rs)
-    // filelimit=2 should exclude it based on raw count (3 > 2)
     fs::create_dir(p.join("big")).unwrap();
     fs::write(p.join("big").join("a.log"), "").unwrap();
     fs::write(p.join("big").join("b.log"), "").unwrap();
     fs::write(p.join("big").join("c.rs"), "").unwrap();
 
-    // Create a directory with 2 entries
     fs::create_dir(p.join("small")).unwrap();
     fs::write(p.join("small").join("d.rs"), "").unwrap();
     fs::write(p.join("small").join("e.log"), "").unwrap();
@@ -463,16 +444,11 @@ fn filelimit_plus_gitignore_uses_raw_count() {
     opts.file_limit = Some(2);
 
     let output = list_directory_as_string(p, &opts).unwrap();
-    // big/ has 3 raw entries (before gitignore filter), so filelimit=2 should skip it
     assert!(
         !output.contains("c.rs"),
         "big/ should be excluded by filelimit (raw count 3 > 2)"
     );
-    // small/ has 2 raw entries, within limit
-    assert!(
-        output.contains("d.rs"),
-        "small/ should be within filelimit"
-    );
+    assert!(output.contains("d.rs"), "small/ should be within filelimit");
 }
 
 #[test]
@@ -551,7 +527,10 @@ fn exclude_plus_gitignore_compose() {
         !output.contains("notes.txt"),
         "Exclude should hide .txt files"
     );
-    assert!(output.contains("code.rs"), "Non-excluded file should appear");
+    assert!(
+        output.contains("code.rs"),
+        "Non-excluded file should appear"
+    );
 }
 
 #[test]
@@ -566,11 +545,9 @@ fn fromfile_plus_gitignore_silently_ignored() {
     opts.from_file = true;
     opts.gitignore = true;
 
-    // Should not crash; gitignore is silently ignored for virtual trees
     let result = list_directory_as_string(&listing_file, &opts);
     assert!(result.is_ok(), "fromfile + gitignore should not crash");
     let output = result.unwrap();
-    // All entries should still appear (gitignore has no effect on fromfile)
     assert!(output.contains("main.rs"));
     assert!(output.contains("out.o"));
 }

--- a/tests/gitignore_tests.rs
+++ b/tests/gitignore_tests.rs
@@ -1,0 +1,576 @@
+use glob::Pattern;
+use rust_tree::rust_tree::options::TreeOptions;
+use rust_tree::rust_tree::traversal::list_directory_as_string;
+use std::fs;
+use tempfile::tempdir;
+
+fn default_options() -> TreeOptions {
+    TreeOptions {
+        all_files: false,
+        level: None,
+        full_path: false,
+        dir_only: false,
+        no_indent: false,
+        print_size: false,
+        human_readable: false,
+        pattern_glob: None,
+        exclude_patterns: vec![],
+        color: false,
+        no_color: false,
+        ascii: false,
+        sort_by_time: false,
+        reverse: false,
+        print_mod_date: false,
+        output_file: None,
+        file_limit: None,
+        dirs_first: false,
+        classify: false,
+        no_report: false,
+        print_permissions: false,
+        from_file: false,
+        icons: false,
+        prune: false,
+        match_dirs: false,
+        gitignore: false,
+    }
+}
+
+fn gitignore_options() -> TreeOptions {
+    let mut opts = default_options();
+    opts.gitignore = true;
+    opts
+}
+
+// ── Basic Filtering ──────────────────────────────────────────────
+
+#[test]
+fn root_gitignore_hides_matched_files_at_root() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::write(p.join("app.rs"), "").unwrap();
+    fs::write(p.join("debug.log"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(output.contains("app.rs"), "Non-ignored file should appear");
+    assert!(
+        !output.contains("debug.log"),
+        "Gitignored file at root should be hidden"
+    );
+}
+
+#[test]
+fn root_gitignore_hides_matched_files_in_subdirectories() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::create_dir(p.join("sub")).unwrap();
+    fs::write(p.join("sub").join("nested.log"), "").unwrap();
+    fs::write(p.join("sub").join("keep.txt"), "").unwrap();
+
+    let output = list_directory_as_string(p, &gitignore_options()).unwrap();
+    assert!(
+        !output.contains("nested.log"),
+        "Gitignored file in subdirectory should be hidden"
+    );
+    assert!(output.contains("keep.txt"), "Non-ignored file should appear");
+}
+
+#[test]
+fn nested_gitignore_applies_only_to_subtree() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::create_dir(p.join("sub")).unwrap();
+    fs::write(p.join("sub").join(".gitignore"), "*.tmp\n").unwrap();
+    fs::write(p.join("root.tmp"), "").unwrap();
+    fs::write(p.join("sub").join("child.tmp"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        output.contains("root.tmp"),
+        "root.tmp should appear (nested rule does not apply at root)"
+    );
+    assert!(
+        !output.contains("child.tmp"),
+        "child.tmp should be hidden by nested .gitignore"
+    );
+}
+
+#[test]
+fn parent_rules_stack_with_child_rules() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::create_dir(p.join("sub")).unwrap();
+    fs::write(p.join("sub").join(".gitignore"), "*.tmp\n").unwrap();
+    fs::write(p.join("sub").join("a.log"), "").unwrap();
+    fs::write(p.join("sub").join("b.tmp"), "").unwrap();
+    fs::write(p.join("sub").join("c.txt"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        !output.contains("a.log"),
+        "Parent rule should hide .log in child"
+    );
+    assert!(
+        !output.contains("b.tmp"),
+        "Child rule should hide .tmp in child"
+    );
+    assert!(output.contains("c.txt"), "Non-ignored file should appear");
+}
+
+#[test]
+fn ignore_file_works_same_as_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".ignore"), "secret.txt\n").unwrap();
+    fs::write(p.join("secret.txt"), "").unwrap();
+    fs::write(p.join("public.txt"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        !output.contains("secret.txt"),
+        ".ignore file should work like .gitignore"
+    );
+    assert!(output.contains("public.txt"));
+}
+
+#[test]
+fn no_op_when_gitignore_flag_not_passed() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::write(p.join("debug.log"), "").unwrap();
+    fs::write(p.join("app.rs"), "").unwrap();
+
+    let mut opts = default_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        output.contains("debug.log"),
+        "Without --gitignore flag, .gitignore should have no effect"
+    );
+    assert!(output.contains("app.rs"));
+}
+
+#[test]
+fn no_op_when_no_gitignore_file_exists() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join("hello.txt"), "").unwrap();
+
+    let output = list_directory_as_string(p, &gitignore_options()).unwrap();
+    assert!(
+        output.contains("hello.txt"),
+        "No .gitignore file should not cause errors or hide files"
+    );
+}
+
+// ── Pattern Types ────────────────────────────────────────────────
+
+#[test]
+fn unanchored_glob_matches_at_any_depth() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::write(p.join("root.log"), "").unwrap();
+    fs::create_dir_all(p.join("a").join("b")).unwrap();
+    fs::write(p.join("a").join("b").join("deep.log"), "").unwrap();
+    fs::write(p.join("a").join("b").join("keep.txt"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(!output.contains("root.log"));
+    assert!(!output.contains("deep.log"));
+    assert!(output.contains("keep.txt"));
+}
+
+#[test]
+fn anchored_pattern_with_slash() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "src/generated\n").unwrap();
+    fs::create_dir_all(p.join("src").join("generated")).unwrap();
+    fs::write(p.join("src").join("generated").join("root_out.rs"), "").unwrap();
+    fs::create_dir_all(p.join("other").join("src").join("generated")).unwrap();
+    fs::write(
+        p.join("other").join("src").join("generated").join("other_out.rs"),
+        "",
+    )
+    .unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // Anchored pattern "src/generated" matches at root only
+    assert!(
+        !output.contains("root_out.rs"),
+        "src/generated/root_out.rs should be hidden by anchored pattern"
+    );
+    // other/src/generated should NOT be matched by anchored pattern
+    assert!(
+        output.contains("other_out.rs"),
+        "other/src/generated/other_out.rs should remain (not anchored at root)"
+    );
+}
+
+#[test]
+fn leading_slash_anchor_matches_only_at_root() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "/build\n").unwrap();
+    fs::create_dir(p.join("build")).unwrap();
+    fs::write(p.join("build").join("out.o"), "").unwrap();
+    fs::create_dir_all(p.join("src").join("build")).unwrap();
+    fs::write(p.join("src").join("build").join("nested.o"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // Root /build should be hidden
+    // But src/build should remain
+    assert!(
+        output.contains("nested.o"),
+        "src/build/nested.o should remain (not anchored at root)"
+    );
+    // Root build dir should be gone
+    let lines: Vec<&str> = output.lines().collect();
+    let has_root_build_content = lines.iter().any(|l| l.contains("out.o"));
+    assert!(
+        !has_root_build_content,
+        "Root build/out.o should be hidden"
+    );
+}
+
+#[test]
+fn dir_only_pattern_matches_directories_not_files() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir(p.join("build")).unwrap();
+    fs::write(p.join("build").join("out.o"), "").unwrap();
+    // Create a file named "build" (not a directory)
+    fs::write(p.join("sub_build"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // The build/ directory should be hidden
+    assert!(
+        !output.contains("out.o"),
+        "Contents of build/ dir should be hidden"
+    );
+    // A file named sub_build should remain (dir-only pattern)
+    assert!(
+        output.contains("sub_build"),
+        "File named sub_build should not be hidden by dir-only pattern"
+    );
+}
+
+#[test]
+fn negation_overrides_previous_rule() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n!important.log\n").unwrap();
+    fs::write(p.join("debug.log"), "").unwrap();
+    fs::write(p.join("important.log"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(!output.contains("debug.log"), "debug.log should be hidden");
+    assert!(
+        output.contains("important.log"),
+        "important.log should be un-ignored by negation"
+    );
+}
+
+#[test]
+fn negation_order_last_match_wins() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(
+        p.join(".gitignore"),
+        "*.log\n!important.log\nimportant.log\n",
+    )
+    .unwrap();
+    fs::write(p.join("important.log"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        !output.contains("important.log"),
+        "Last match wins: re-ignoring important.log should hide it"
+    );
+}
+
+#[test]
+fn parent_dir_exclusion_blocks_child_negation() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    // Ignore the build directory, then try to un-ignore a file inside it
+    // Git behavior: if parent dir is excluded, child negation cannot bring it back
+    fs::write(p.join(".gitignore"), "build/\n!build/output.txt\n").unwrap();
+    fs::create_dir(p.join("build")).unwrap();
+    fs::write(p.join("build").join("output.txt"), "").unwrap();
+    fs::write(p.join("build").join("other.o"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // The build directory itself is excluded, so nothing inside can be un-ignored
+    assert!(
+        !output.contains("output.txt"),
+        "Cannot un-ignore file inside excluded parent directory"
+    );
+    assert!(!output.contains("other.o"));
+}
+
+// ── Flag Combinations ────────────────────────────────────────────
+
+#[test]
+fn prune_plus_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::create_dir(p.join("logs_only")).unwrap();
+    fs::write(p.join("logs_only").join("app.log"), "").unwrap();
+    fs::create_dir(p.join("mixed")).unwrap();
+    fs::write(p.join("mixed").join("code.rs"), "").unwrap();
+    fs::write(p.join("mixed").join("debug.log"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.pattern_glob = Some(Pattern::new("*.rs").unwrap());
+    opts.prune = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        output.contains("mixed"),
+        "mixed dir has .rs files, should survive prune"
+    );
+    assert!(output.contains("code.rs"));
+    assert!(
+        !output.contains("logs_only"),
+        "logs_only has only .log files (gitignored), should be pruned"
+    );
+}
+
+#[test]
+fn pattern_plus_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::write(p.join("app.log"), "").unwrap();
+    fs::write(p.join("code.rs"), "").unwrap();
+    fs::write(p.join("data.txt"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.pattern_glob = Some(Pattern::new("*.log").unwrap());
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // *.log matches the pattern filter, but gitignore also hides *.log
+    // gitignore should take precedence
+    assert!(
+        !output.contains("app.log"),
+        "Gitignored files excluded despite matching -P pattern"
+    );
+}
+
+#[test]
+fn matchdirs_plus_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.tmp\n").unwrap();
+    fs::create_dir_all(p.join("mymod")).unwrap();
+    fs::write(p.join("mymod").join("code.rs"), "").unwrap();
+    fs::write(p.join("mymod").join("cache.tmp"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.pattern_glob = Some(Pattern::new("mymod").unwrap());
+    opts.match_dirs = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(output.contains("mymod"));
+    assert!(output.contains("code.rs"), "Non-ignored child should show");
+    assert!(
+        !output.contains("cache.tmp"),
+        "Gitignored files hidden inside matched dirs"
+    );
+}
+
+#[test]
+fn filelimit_plus_gitignore_uses_raw_count() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    // Create a directory with 3 total entries (2 .log + 1 .rs)
+    // filelimit=2 should exclude it based on raw count (3 > 2)
+    fs::create_dir(p.join("big")).unwrap();
+    fs::write(p.join("big").join("a.log"), "").unwrap();
+    fs::write(p.join("big").join("b.log"), "").unwrap();
+    fs::write(p.join("big").join("c.rs"), "").unwrap();
+
+    // Create a directory with 2 entries
+    fs::create_dir(p.join("small")).unwrap();
+    fs::write(p.join("small").join("d.rs"), "").unwrap();
+    fs::write(p.join("small").join("e.log"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.file_limit = Some(2);
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    // big/ has 3 raw entries (before gitignore filter), so filelimit=2 should skip it
+    assert!(
+        !output.contains("c.rs"),
+        "big/ should be excluded by filelimit (raw count 3 > 2)"
+    );
+    // small/ has 2 raw entries, within limit
+    assert!(
+        output.contains("d.rs"),
+        "small/ should be within filelimit"
+    );
+}
+
+#[test]
+fn hidden_plus_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), ".secret\n").unwrap();
+    fs::write(p.join(".hidden"), "").unwrap();
+    fs::write(p.join(".secret"), "").unwrap();
+    fs::write(p.join("visible.txt"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        output.contains(".hidden"),
+        "Hidden files shown with -a unless gitignored"
+    );
+    assert!(
+        !output.contains(".secret"),
+        ".secret should be hidden by gitignore"
+    );
+    assert!(output.contains("visible.txt"));
+}
+
+#[test]
+fn dir_only_plus_gitignore() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "build/\n").unwrap();
+    fs::create_dir(p.join("src")).unwrap();
+    fs::create_dir(p.join("build")).unwrap();
+    fs::write(p.join("src").join("main.rs"), "").unwrap();
+    fs::write(p.join("build").join("out.o"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.dir_only = true;
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(output.contains("src"), "Non-ignored dir should appear");
+    assert!(
+        !output.contains("build"),
+        "Dir-only gitignore pattern should hide build/ in -d mode"
+    );
+}
+
+#[test]
+fn exclude_plus_gitignore_compose() {
+    let dir = tempdir().unwrap();
+    let p = dir.path();
+
+    fs::write(p.join(".gitignore"), "*.log\n").unwrap();
+    fs::write(p.join("debug.log"), "").unwrap();
+    fs::write(p.join("readme.txt"), "").unwrap();
+    fs::write(p.join("notes.txt"), "").unwrap();
+    fs::write(p.join("code.rs"), "").unwrap();
+
+    let mut opts = gitignore_options();
+    opts.all_files = true;
+    opts.exclude_patterns = vec![Pattern::new("*.txt").unwrap()];
+
+    let output = list_directory_as_string(p, &opts).unwrap();
+    assert!(
+        !output.contains("debug.log"),
+        "Gitignore should hide .log files"
+    );
+    assert!(
+        !output.contains("readme.txt"),
+        "Exclude should hide .txt files"
+    );
+    assert!(
+        !output.contains("notes.txt"),
+        "Exclude should hide .txt files"
+    );
+    assert!(output.contains("code.rs"), "Non-excluded file should appear");
+}
+
+#[test]
+fn fromfile_plus_gitignore_silently_ignored() {
+    let dir = tempdir().unwrap();
+    let listing_file = dir.path().join("listing.txt");
+
+    let content = "src/\nsrc/main.rs\nbuild/\nbuild/out.o\n";
+    fs::write(&listing_file, content).unwrap();
+
+    let mut opts = default_options();
+    opts.from_file = true;
+    opts.gitignore = true;
+
+    // Should not crash; gitignore is silently ignored for virtual trees
+    let result = list_directory_as_string(&listing_file, &opts);
+    assert!(result.is_ok(), "fromfile + gitignore should not crash");
+    let output = result.unwrap();
+    // All entries should still appear (gitignore has no effect on fromfile)
+    assert!(output.contains("main.rs"));
+    assert!(output.contains("out.o"));
+}

--- a/tests/traversal_tests.rs
+++ b/tests/traversal_tests.rs
@@ -57,6 +57,7 @@ fn create_default_options() -> TreeOptions {
         icons: false,
         prune: false,
         match_dirs: false,
+        gitignore: false,
     }
 }
 

--- a/tests/unit_tests.rs
+++ b/tests/unit_tests.rs
@@ -35,6 +35,7 @@ fn create_basic_options() -> TreeOptions {
         icons: false,
         prune: false,
         match_dirs: false,
+        gitignore: false,
     }
 }
 


### PR DESCRIPTION
Add support for filtering out gitignored files by use of a new `--gitignore` flag. 

- Zero impact to `tree` when flag is not used - Only considers ignore files if the flag is used - no new undesired compute
- Minimal cost when on, we only check the files when walking the tree, cost scales with ignore files
- No new dependencies - Implements gitignore parsing, using existing `glob`
- Composes with all existing flags

Note: does not consider global ignores (eg gitignore, git info exclude), I'm not sure it's reasonable to look 

Usage Examples
```bash
# Show tree without gitignored files
tree --gitignore

# Combine with other flags as expected
tree --gitignore --prune          # also remove empty directories
tree --gitignore -P "*.rs"        # only Rust files, minus gitignored ones
tree --gitignore -a               # show hidden files, but not gitignored ones
```


Resolves #57 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--gitignore` flag to respect .gitignore and .ignore files during directory listing
  * Supports comprehensive gitignore pattern matching including negation rules, anchored patterns, and directory-only specifications
  * Automatically loads and applies ignore rules recursively across subdirectories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->